### PR TITLE
Adding ccsearch.creativecommons.org to whitelist

### DIFF
--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -39,7 +39,8 @@ ALLOWED_HOSTS = ['localhost', '127.0.0.1', os.environ.get('LOAD_BALANCER_URL'),
 SHORT_URL_WHITELIST = {
     'api-dev.creativecommons.engineering',
     'api.creativecommons.engineering',
-    'ccccatalog.herokuapp.com'
+    'ccccatalog.herokuapp.com',
+    'ccsearch.creativecommons.org',
 }
 SHORT_URL_PATH_WHITELIST = ['/list', '/image/']
 


### PR DESCRIPTION
When shortened urls, we need to ensure that it works for `ccsearch.creativecommons.org`.