### PR TITLE
Don't crash if we're missing content provider information. #172

### DIFF
--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -143,11 +143,15 @@ class ImageDetail(GenericAPIView, RetrieveModelMixin):
         resp = self.retrieve(request, identifier)
         # Get pretty display name for a provider
         provider = resp.data['provider']
-        provider_data = ContentProvider \
-            .objects \
-            .get(provider_identifier=provider)
-        resp.data['provider'] = provider_data.provider_name
-        resp.data['provider_url'] = provider_data.domain_name
+        try:
+            provider_data = ContentProvider \
+                .objects \
+                .get(provider_identifier=provider)
+            resp.data['provider'] = provider_data.provider_name
+            resp.data['provider_url'] = provider_data.domain_name
+        except ContentProvider.DoesNotExist:
+            resp.data['provider'] = provider
+            resp.data['provider_url'] = 'Unknown'
         # Add page views to the response.
         resp.data['view_count'] = view_count
         # Fix links to creator and foreign landing URLs.

--- a/cccatalog-api/test/run_test.sh
+++ b/cccatalog-api/test/run_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Local environments don't have valid certificates; suppress this warning.
+export PYTHONWARNINGS="ignore:Unverified HTTPS request"
+pytest -s

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -4,6 +4,7 @@ docker exec -ti cccatalog-api_web_1 /bin/bash -c 'python3 manage.py makemigratio
 docker exec -ti cccatalog-api_web_1 /bin/bash -c 'python3 manage.py migrate'
 PGPASSWORD=deploy pg_dump -s -t image -U deploy -d openledger -h localhost -p 5432 | PGPASSWORD=deploy psql -U deploy -d openledger -p 5433 -h localhost
 # Load sample data
+PGPASSWORD=deploy psql -U deploy -d openledger -h localhost -p 5433 -c "INSERT INTO content_provider (created_on, provider_identifier, provider_name, domain_name, filter_content) VALUES (now(), 'flickr', 'Flickr', 'https://www.flickr.com', false);"
 PGPASSWORD=deploy psql -U deploy -d openledger -h localhost -p 5433 -c "\copy image (id,created_on,updated_on,provider,source,foreign_identifier,foreign_landing_url,url,thumbnail,width,height,filesize,license,license_version,creator,creator_url,title,tags_list,last_synced_with_source,removed_from_source,meta_data,view_count,tags,watermarked,identifier) from 'sample_data.csv' with csv header"
 # Ingest and index the data
 curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model": "image", "action": "INGEST_UPSTREAM"}'


### PR DESCRIPTION
If a provider is missing from the `content_provider` table, the image detail view crashes. This PR adds a generic fallback for when the data is missing.