### PR TITLE
Result count, tag search improvements #161 creativecommons/cccatalog-frontend#147

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -71,7 +71,7 @@ def search(search_params, index, page_size, page=1) -> Response:
     keywords = ' '.join(search_params.data['q'].lower().split(','))
     s = s.query("constant_score", filter=Q("multi_match",
                 query=keywords,
-                fields=['detailed_tags', 'tags', 'title'],
+                fields=['legacy_tags', 'tags.name', 'title'],
                 operator='AND'))
     s.extra(track_scores=True)
     search_response = s.execute()

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -46,6 +46,12 @@ class _SearchQueryStringSerializer(serializers.Serializer):
                   " appear.",
         required=False
     )
+    filter_dead = serializers.BooleanField(
+        label="filter_dead",
+        help_text="Control whether 404 links are filtered out.",
+        required=False,
+        default=True
+    )
 
     def validate(self, data):
         if 'li' in data and 'lt' in data:

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -22,6 +22,7 @@ RESULTS = 'results'
 PAGE = 'page'
 PAGESIZE = 'pagesize'
 VALIDATION_ERROR = 'validation_error'
+FILTER_DEAD = 'filter_dead'
 
 
 def _add_protocol(url: str):
@@ -92,7 +93,8 @@ class SearchImages(APIView):
             result.detail = url
             to_validate.append(result.url)
             results.append(result)
-        validate_images(results, to_validate)
+        if params.data[FILTER_DEAD]:
+            validate_images(results, to_validate)
         serialized_results =\
             ImageSerializer(results, many=True).data
         # Elasticsearch does not allow deep pagination of ranked queries.

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -103,8 +103,11 @@ class SearchImages(APIView):
         last_allowed_page = int((5000 + page_size / 2) / page_size)
         page_count = min(natural_page_count, last_allowed_page)
 
+        result_count = search_results.hits.total
+        if len(results) < page_size:
+            result_count = len(results)
         response_data = {
-            'result_count': search_results.hits.total,
+            'result_count': result_count,
             'page_count': page_count,
             RESULTS: serialized_results
         }

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -4,7 +4,7 @@ CCCAPI_CONTAINER_NAME="${CCCAPI_CONTAINER_NAME:-cccatalog-api_web_1}"
 docker exec -ti $CCCAPI_CONTAINER_NAME /bin/bash -c 'python3 manage.py migrate --noinput'
 PGPASSWORD=deploy pg_dump -s -t image -U deploy -d openledger -h localhost -p 5432 | PGPASSWORD=deploy psql -U deploy -d openledger -p 5433 -h localhost
 # Load sample data
-PGPASSWORD=deploy psql -U deploy -d openledger -h localhost -p 5432 -c "INSERT INTO content_provider (created_on, provider_identifier, provider_name, domain_name, filter_content) VALUES (now(), 'flickr', 'Flickr', 'https://www.flickr.com', false);"
-PGPASSWORD=deploy psql -U deploy -d openledger -h localhost -p 5433 -c "\copy image (id,created_on,updated_on,provider,source,foreign_identifier,foreign_landing_url,url,thumbnail,width,height,filesize,license,license_version,creator,creator_url,title,tags_list,last_synced_with_source,removed_from_source,meta_data,view_count,tags,watermarked,identifier) from 'sample_data.csv' with csv header"
+PGPASSWORD=deploy psql -U deploy -d openledger -h localhost -p 5432 -c "INSERT INTO content_provider (created_on, provider_identifier, provider_name, domain_name, filter_content) VALUES (now(), 'flickr', 'Flickr', 'https://www.flickr.com', false), (now(), 'behance', 'Behance', 'https://www.behance.net', false);"
+PGPASSWORD=deploy psql -U deploy -d openledger -h localhost -p 5433 -c "\copy image (id,created_on,updated_on,identifier,provider,source,foreign_identifier,foreign_landing_url,url,thumbnail,width,height,filesize,license,license_version,creator,creator_url,title,tags_list,last_synced_with_source,removed_from_source,meta_data,tags,watermarked,view_count) from 'sample_data.csv' with csv header"
 # Ingest and index the data
 curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model": "image", "action": "INGEST_UPSTREAM"}'


### PR DESCRIPTION
This PR includes:
- A more accurate page count in cases where all of the links are dead and filtered
- A new parameter `filter_dead` which allows consumers to disable dead link filtering. This is mostly for debugging purposes.
- Better sample data
- Renamed tag fields