### PR TITLE
Remove unused legacy field from the application. #181

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -71,7 +71,7 @@ def search(search_params, index, page_size, page=1) -> Response:
     keywords = ' '.join(search_params.data['q'].lower().split(','))
     s = s.query("constant_score", filter=Q("multi_match",
                 query=keywords,
-                fields=['legacy_tags', 'tags.name', 'title'],
+                fields=['tags.name', 'title'],
                 operator='AND'))
     s.extra(track_scores=True)
     search_response = s.execute()

--- a/cccatalog-api/cccatalog/api/models.py
+++ b/cccatalog-api/cccatalog/api/models.py
@@ -85,12 +85,6 @@ class Image(OpenLedgerModel):
 
     title = models.CharField(max_length=2000, blank=True, null=True)
 
-    tags_list = ArrayField(models.CharField(
-        max_length=255),
-        blank=True,
-        null=True
-    )
-
     tags = JSONField(blank=True, null=True)
 
     last_synced_with_source = models.DateTimeField(

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -68,7 +68,6 @@ class Image(SyncableDocType):
             identifier=row[schema['identifier']],
             creator=row[schema['creator']],
             creator_url=row[schema['creator_url']],
-            legacy_tags=row[schema['tags_list']],
             tags=_parse_detailed_tags(row[schema['tags']]),
             created_on=row[schema['created_on']],
             url=row[schema['url']],


### PR DESCRIPTION
We no longer use `tags_list`; all tags have been consolidated to the new format in the `tags` field.