### PR TITLE
Route insecure HTTP images through a proxy #191

### DIFF
--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -124,9 +124,9 @@ class SearchImages(APIView):
         # HTTP thumbnails.
         for idx, res in enumerate(serialized_results):
             if PROXY_THUMBS:
-                active_image = THUMBNAIL if THUMBNAIL in res else URL
-                if 'http://' in res[active_image]:
-                    original = res[URL]
+                to_proxy = THUMBNAIL if THUMBNAIL in res else URL
+                if 'http://' in res[to_proxy]:
+                    original = res[to_proxy]
                     secure = '{proxy_url}/{width}/{original}'.format(
                         proxy_url=THUMBNAIL_PROXY_URL,
                         width=THUMBNAIL_WIDTH_PX,

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -41,8 +41,10 @@ def _add_protocol(url: str):
     else:
         return url
 
+
 def _post_process_results():
     pass
+
 
 class SearchImages(APIView):
     """
@@ -124,7 +126,6 @@ class SearchImages(APIView):
         # Post-process the search results to fix malformed URLs and insecure
         # HTTP thumbnails.
         for idx, res in enumerate(serialized_results):
-            #
             to_proxy = THUMBNAIL if THUMBNAIL in res else URL
             if 'http://' in res[to_proxy]:
                 original = res[to_proxy]

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -124,9 +124,9 @@ class SearchImages(APIView):
         # HTTP thumbnails.
         for idx, res in enumerate(serialized_results):
             if PROXY_THUMBS:
-                to_proxy = THUMBNAIL if THUMBNAIL in res else URL
-                if 'http://' in res[to_proxy]:
-                    original = res[to_proxy]
+                active_image = THUMBNAIL if THUMBNAIL in res else URL
+                if 'http://' in res[active_image]:
+                    original = res[URL]
                     secure = '{proxy_url}/{width}/{original}'.format(
                         proxy_url=THUMBNAIL_PROXY_URL,
                         width=THUMBNAIL_WIDTH_PX,

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -42,10 +42,6 @@ def _add_protocol(url: str):
         return url
 
 
-def _post_process_results():
-    pass
-
-
 class SearchImages(APIView):
     """
     Search for images by keyword. Optionally, filter the results by specific

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -11,7 +11,7 @@ from cccatalog.api.serializers.search_serializers import\
     ImageSearchResultsSerializer, ImageSerializer,\
     ValidationErrorSerializer, ImageSearchQueryStringSerializer
 from cccatalog.api.serializers.image_serializers import ImageDetailSerializer
-from cccatalog.settings import THUMBNAIL_PROXY_URL
+from cccatalog.settings import THUMBNAIL_PROXY_URL, PROXY_THUMBS
 from cccatalog.api.utils.view_count import _get_user_ip
 import cccatalog.api.controllers.search_controller as search_controller
 import logging
@@ -122,11 +122,12 @@ class SearchImages(APIView):
         # Post-process the search results to fix malformed URLs and insecure
         # HTTP thumbnails.
         for idx, res in enumerate(serialized_results):
-            to_proxy = THUMBNAIL if THUMBNAIL in res else URL
-            if 'http://' in res[to_proxy] or THUMBNAIL not in res:
-                original = res[to_proxy]
-                secure = THUMBNAIL_PROXY_URL + original
-                response_data[RESULTS][idx][THUMBNAIL] = secure
+            if PROXY_THUMBS:
+                to_proxy = THUMBNAIL if THUMBNAIL in res else URL
+                if 'http://' in res[to_proxy]:
+                    original = res[to_proxy]
+                    secure = THUMBNAIL_PROXY_URL + original
+                    response_data[RESULTS][idx][THUMBNAIL] = secure
             if FOREIGN_LANDING_URL in res:
                 foreign = _add_protocol(res[FOREIGN_LANDING_URL])
                 response_data[RESULTS][idx][FOREIGN_LANDING_URL] = foreign

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -41,6 +41,8 @@ def _add_protocol(url: str):
     else:
         return url
 
+def _post_process_results():
+    pass
 
 class SearchImages(APIView):
     """
@@ -122,11 +124,12 @@ class SearchImages(APIView):
         # Post-process the search results to fix malformed URLs and insecure
         # HTTP thumbnails.
         for idx, res in enumerate(serialized_results):
+            #
             to_proxy = THUMBNAIL if THUMBNAIL in res else URL
             if 'http://' in res[to_proxy]:
                 original = res[to_proxy]
                 secure = THUMBNAIL_PROXY_URL + original
-                response_data[RESULTS][idx][to_proxy] = secure
+                response_data[RESULTS][idx][THUMBNAIL] = secure
             if FOREIGN_LANDING_URL in res:
                 foreign = _add_protocol(res[FOREIGN_LANDING_URL])
                 response_data[RESULTS][idx][FOREIGN_LANDING_URL] = foreign

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -127,7 +127,7 @@ class SearchImages(APIView):
         # HTTP thumbnails.
         for idx, res in enumerate(serialized_results):
             to_proxy = THUMBNAIL if THUMBNAIL in res else URL
-            if 'http://' in res[to_proxy]:
+            if 'http://' in res[to_proxy] or THUMBNAIL not in res:
                 original = res[to_proxy]
                 secure = THUMBNAIL_PROXY_URL + original
                 response_data[RESULTS][idx][THUMBNAIL] = secure

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -141,11 +141,13 @@ CACHES = {
     }
 }
 
+# Produce thumbnails on-the-fly when HTTPS is not supported.
+PROXY_THUMBS = bool(os.environ.get('PROXY_THUMBS', False))
 # Width of thumbnils
 THUMB_SIZE_PX = int(os.environ.get('THUMB_SIZE_PX', 600))
 THUMBNAIL_PROXY_URL = os.environ.get(
     'THUMBNAIL_PROXY_URL',
-    'localhost:8222/{}/'.format(THUMB_SIZE_PX)
+    'https://localhost:8222/{}/'.format(THUMB_SIZE_PX)
 )
 
 AUTHENTICATION_BACKENDS = (

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -141,6 +141,13 @@ CACHES = {
     }
 }
 
+# Width of thumbnils
+THUMB_SIZE_PX = int(os.environ.get('THUMB_SIZE_PX', 600))
+THUMBNAIL_PROXY_URL = os.environ.get(
+    'THUMBNAIL_PROXY_URL',
+    'localhost:8222/{}/'.format(THUMB_SIZE_PX)
+)
+
 AUTHENTICATION_BACKENDS = (
     # GitHub social login
     'social_core.backends.github.GithubOAuth2',

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -143,11 +143,8 @@ CACHES = {
 
 # Produce thumbnails on-the-fly when HTTPS is not supported.
 PROXY_THUMBS = bool(os.environ.get('PROXY_THUMBS', False))
-# Width of thumbnils
-THUMB_SIZE_PX = int(os.environ.get('THUMB_SIZE_PX', 600))
 THUMBNAIL_PROXY_URL = os.environ.get(
-    'THUMBNAIL_PROXY_URL',
-    'https://localhost:8222/{}/'.format(THUMB_SIZE_PX)
+    'THUMBNAIL_PROXY_URL', 'https://localhost:8222'
 )
 
 AUTHENTICATION_BACKENDS = (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
     healthcheck:
       test: "pg_isready -U deploy -d openledger"
 
+  thumbs:
+    image: willnorris/imageproxy
+    ports:
+      - "8222:8222"
+    command: ["-addr", "0.0.0.0:8222"]
+
   upstream_db:
     image: postgres:10.3-alpine
     ports:


### PR DESCRIPTION
We cannot display images without HTTPS on the front end without compromising the SSL security of the website, which browsers nowadays will loudly complain about and spook our users. More importantly, [there is no excuse for using insecure HTTP in 2019.](https://https.cio.gov/everything/). This causes problems for us because some of the providers in our catalog have not bothered to set up HTTPS on their servers. Since we do not want to exclude these providers entirely from our catalog or fail to render the images, we need to produce our own SSL-secured thumbnails.