### PR TITLE
Upgrade Django to fix memory exhaustion vulnerability

### DIFF
--- a/cccatalog-api/requirements.txt
+++ b/cccatalog-api/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2018.4.16
 chardet==3.0.4
 defusedxml==0.5.0
-django==2.0.11
+django==2.0.13
 django-braces==1.13.0
 django-oauth-toolkit==1.1.2
 django-rest-framework-social-oauth2==1.1.0

--- a/cccatalog-api/requirements.txt
+++ b/cccatalog-api/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2018.4.16
 chardet==3.0.4
 defusedxml==0.5.0
-Django==2.0.10
+django==2.0.11
 django-braces==1.13.0
 django-oauth-toolkit==1.1.2
 django-rest-framework-social-oauth2==1.1.0


### PR DESCRIPTION
[CVE-2019-6975](https://nvd.nist.gov/vuln/detail/CVE-2019-6975)

[Relevant post on Django blog](https://www.djangoproject.com/weblog/2019/feb/11/security-releases/)