### PR TITLE
Workaround MET providing incorrect status codes and content types [#198, #197]

### DIFF
--- a/cccatalog-api/cccatalog/api/utils/validate_images.py
+++ b/cccatalog-api/cccatalog/api/utils/validate_images.py
@@ -42,6 +42,9 @@ def validate_images(results, image_urls):
         cache_key = cache_prefix + url
         if verified[idx]:
             status = verified[idx].status_code
+            # In case of weird redirects or incorrect content types in links
+            if 'text/html' in verified[idx].headers['Content-Type']:
+                status = 404
         # Response didn't arrive in time. Try again later.
         else:
             status = -1

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -11,7 +11,7 @@ from cccatalog.api.serializers.search_serializers import\
     ImageSearchResultsSerializer, ImageSerializer,\
     ValidationErrorSerializer, ImageSearchQueryStringSerializer
 from cccatalog.api.serializers.image_serializers import ImageDetailSerializer
-from cccatalog.settings import THUMBNAIL_PROXY_URL, PROXY_THUMBS
+from cccatalog.settings import THUMBNAIL_PROXY_URL, PROXY_THUMBS, PROXY_ALL
 from cccatalog.api.utils.view_count import _get_user_ip
 import cccatalog.api.controllers.search_controller as search_controller
 import logging
@@ -127,11 +127,12 @@ class SearchImages(APIView):
             if PROXY_THUMBS:
                 provider = res[PROVIDER]
                 # Proxy either the thumbnail or URL, depending on whether
-                # a thumbnail was provided. Never use MET thumbnails; they're
-                # usually broken.
-                to_proxy = \
-                    THUMBNAIL if THUMBNAIL in res and provider != 'met' else URL
-                if 'http://' in res[to_proxy] or provider == 'met':
+                # a thumbnail was provided.
+                if THUMBNAIL in res and provider not in PROXY_ALL:
+                    to_proxy = THUMBNAIL
+                else:
+                    to_proxy = URL
+                if 'http://' in res[to_proxy] or provider in PROXY_ALL:
                     original = res[to_proxy]
                     secure = '{proxy_url}/{width}/{original}'.format(
                         proxy_url=THUMBNAIL_PROXY_URL,

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -147,6 +147,10 @@ THUMBNAIL_PROXY_URL = os.environ.get(
     'THUMBNAIL_PROXY_URL', 'https://localhost:8222'
 )
 
+# Some 3rd party content providers provide low quality or broken thumbnails
+# frequently. We produce our own thumbnails for the worst offenders.
+PROXY_ALL = os.environ.get('PROXY_ALL', 'met,iha').split(',')
+
 AUTHENTICATION_BACKENDS = (
     # GitHub social login
     'social_core.backends.github.GithubOAuth2',


### PR DESCRIPTION
- Treat `text/html` content type as 404s
- Route all MET images through the thumbnail proxy. They're too frequently moved or broken.