### PR TITLE
Burst and sustained rate limit

### DIFF
--- a/cccatalog-api/cccatalog/api/utils/throttle.py
+++ b/cccatalog-api/cccatalog/api/utils/throttle.py
@@ -3,3 +3,11 @@ from rest_framework.throttling import AnonRateThrottle
 
 class PostRequestThrottler(AnonRateThrottle):
     rate = '30/day'
+
+
+class BurstRateThrottle(AnonRateThrottle):
+    scope = 'burst'
+
+
+class SustainedRateThrottle(AnonRateThrottle):
+    scope = 'sustained'

--- a/cccatalog-api/cccatalog/api/utils/validate_images.py
+++ b/cccatalog-api/cccatalog/api/utils/validate_images.py
@@ -42,9 +42,6 @@ def validate_images(results, image_urls):
         cache_key = cache_prefix + url
         if verified[idx]:
             status = verified[idx].status_code
-            # In case of weird redirects or incorrect content types in links
-            if 'text/html' in verified[idx].headers['Content-Type']:
-                status = 404
         # Response didn't arrive in time. Try again later.
         else:
             status = -1

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -86,6 +86,7 @@ SWAGGER_SETTINGS = {
     'SECURITY_DEFINITIONS': {}
 }
 
+
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
@@ -96,12 +97,12 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_THROTTLE_CLASSES': (
-        'rest_framework.throttling.AnonRateThrottle',
-        'rest_framework.throttling.UserRateThrottle'
+        'cccatalog.utils.throttle.BurstRateThrottle',
+        'rest_framework.throttling.SustainedRateThrottle'
     ),
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '1000/day',
-        'user': '1000/day'
+        'burst': '60/min',
+        'sustained': '7000/day'
     },
 }
 

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -150,7 +150,7 @@ THUMBNAIL_PROXY_URL = os.environ.get(
 
 # Some 3rd party content providers provide low quality or broken thumbnails
 # frequently. We produce our own thumbnails for the worst offenders.
-PROXY_ALL = os.environ.get('PROXY_ALL', 'met,iha').split(',')
+PROXY_ALL = os.environ.get('PROXY_ALL', 'iha').split(',')
 
 AUTHENTICATION_BACKENDS = (
     # GitHub social login

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -97,8 +97,8 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_THROTTLE_CLASSES': (
-        'cccatalog.utils.throttle.BurstRateThrottle',
-        'rest_framework.throttling.SustainedRateThrottle'
+        'cccatalog.api.utils.throttle.BurstRateThrottle',
+        'cccatalog.api.utils.throttle.SustainedRateThrottle'
     ),
     'DEFAULT_THROTTLE_RATES': {
         'burst': '60/min',

--- a/cccatalog-api/cccatalog/urls.py
+++ b/cccatalog-api/cccatalog/urls.py
@@ -34,9 +34,10 @@ articles, songs, videos, photographs, paintings, and more. Using this API,
 developers will be able to access the digital commons in their own
 applications.
 
-Please note that there is a rate limit of 1000 requests per day in place. If
-this is insufficient for your use case, please contact us so we can issue you
-an API key with higher throughput enabled.
+Please note that there is a rate limit of 7000 requests per day and
+60 requests per minute rate limit in place. If this is insufficient
+for your use case, please contact us so we can issue you an API key with
+higher throughput enabled.
 """
 
 


### PR DESCRIPTION
- Curb overzealous rate limit; raise limit to 7k requests per day with bursts of 60/min. The 1000 daily request rate limit was impacting too many users.
- Proxy all IHA thumbnails. They're too small. Revisit the MET at a later date.