### PR TITLE
Fix license type filters #202

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ before_script:
 script:
   - pycodestyle cccatalog-api/cccatalog --exclude='cccatalog-api/cccatalog/api/migrations' --max-line-length=80 --ignore=E402 
   - pycodestyle ingestion_server/*.py --max-line-length=80 --ignore=E402
-  - cd cccatalog-api/test && ./run_test.sh
+  - cd cccatalog-api && test/run_test.sh
   - cd ../../ingestion_server && python3 test/integration_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - postgresql-client-10
 env:
   - CCCAPI_CONTAINER_NAME=cccatalogapi_web_1
+  - PYTHONPATH=.
 python:
 - '3.6'
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
       - postgresql-client-10
 env:
   - CCCAPI_CONTAINER_NAME=cccatalogapi_web_1
-  - PYTHONPATH=.
 python:
 - '3.6'
 services:
@@ -14,6 +13,8 @@ services:
 install:
   - pip3 install -r ingestion_server/requirements.txt
   - pip3 install -r cccatalog-api/requirements.txt
+before_install:
+  - "export PYTHONPATH=$PYTHONPATH:$(pwd)"
 before_script:
   - sudo service postgresql stop
   - while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
   - pycodestyle cccatalog-api/cccatalog --exclude='cccatalog-api/cccatalog/api/migrations' --max-line-length=80 --ignore=E402 
   - pycodestyle ingestion_server/*.py --max-line-length=80 --ignore=E402
   - cd cccatalog-api && test/run_test.sh
-  - cd ../../ingestion_server && python3 test/integration_tests.py
+  - cd ../ingestion_server && python3 test/integration_tests.py

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -44,7 +44,10 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
         license_filters = []
         for _license in search_params.data[license_field].split(','):
             license_filters.append(Q('term', license__keyword=_license))
-        s = s.filter('bool', should=license_filters, minimum_should_match=1)
+        if license_field == 'lt':
+            s = s.filter('bool', must=license_filters, minimum_should_match=1)
+        else:
+            s = s.filter('bool', should=license_filters, minimum_should_match=1)
     if 'provider' in search_params.data:
         provider_filters = []
         for provider in search_params.data['provider'].split(','):

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -44,10 +44,7 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
         license_filters = []
         for _license in search_params.data[license_field].split(','):
             license_filters.append(Q('term', license__keyword=_license))
-        if license_field == 'lt':
-            s = s.filter('bool', must=license_filters, minimum_should_match=1)
-        else:
-            s = s.filter('bool', should=license_filters, minimum_should_match=1)
+        s = s.filter('bool', should=license_filters, minimum_should_match=1)
     if 'provider' in search_params.data:
         provider_filters = []
         for provider in search_params.data['provider'].split(','):

--- a/cccatalog-api/cccatalog/api/licenses.py
+++ b/cccatalog-api/cccatalog/api/licenses.py
@@ -14,7 +14,7 @@ LICENSE_GROUPS = {
     "all": {'BY', 'BY-NC', 'BY-ND', 'BY-SA', 'BY-NC-ND', 'BY-NC-SA', 'PDM',
             'CC0'},
     # All CC licenses
-    "all-cc": {'BY', 'BY-NC', 'BY-ND', 'BY-SA', 'BY-NC-ND', 'BY-NC-SA'},
+    "all-cc": {'BY', 'BY-NC', 'BY-ND', 'BY-SA', 'BY-NC-ND', 'BY-NC-SA', 'CC0'},
     # All licenses allowing commercial use
     "commercial": {'BY', 'BY-SA', 'BY-ND', 'CC0', 'PDM'},
     # All licenses allowing modifications

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -106,9 +106,7 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
                 )
             license_groups.append(LICENSE_GROUPS[_type])
         intersected = set.intersection(*license_groups)
-        cleaned = []
-        for _license in intersected:
-            cleaned.append(_license.lower())
+        cleaned = {_license.lower() for _license in intersected}
 
         return ','.join(list(cleaned))
 

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -94,21 +94,23 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
 
     def validate_lt(self, value):
         """
-        Resolves a license type to a list of licenses.
+        Resolves a list of license types to a list of licenses.
         Example: commercial -> ['BY', 'BY-SA', 'BY-ND', 'CC0', 'PDM']
         """
         license_types = [x.lower() for x in value.split(',')]
-        resolved_licenses = set()
+        license_groups = []
         for _type in license_types:
             if _type not in LICENSE_GROUPS:
                 raise serializers.ValidationError(
                     "License type \'{}\' does not exist.".format(_type)
                 )
-            licenses = LICENSE_GROUPS[_type]
-            for _license in licenses:
-                resolved_licenses.add(_license.lower())
+            license_groups.append(LICENSE_GROUPS[_type])
+        intersected = set.intersection(*license_groups)
+        cleaned = []
+        for _license in intersected:
+            cleaned.append(_license.lower())
 
-        return ','.join(list(resolved_licenses))
+        return ','.join(list(cleaned))
 
     def validate_page(self, value):
         if value < 1:

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -156,7 +156,6 @@ def test_single_license_type_filtering():
 
 
 def test_specific_license_filter():
-    license = 'by'
     response = requests.get(API_URL + '/image/search?q=a&li=by')
     parsed = json.loads(response.text)
     for result in parsed['results']:

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -153,3 +153,11 @@ def test_single_license_type_filtering():
     parsed = json.loads(response.text)
     for result in parsed['results']:
         assert result['license'].upper() in commercial
+
+
+def test_specific_license_filter():
+    license = 'by'
+    response = requests.get(API_URL + '/image/search?q=a&li=by')
+    parsed = json.loads(response.text)
+    for result in parsed['results']:
+        assert result['license'] == 'by'

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -2,6 +2,7 @@ import requests
 import json
 import pytest
 import os
+from cccatalog.api.licenses import LICENSE_GROUPS
 
 """
 End-to-end API tests. Can be used to verify a live deployment is functioning as
@@ -136,8 +137,8 @@ def test_license_type_filtering():
     """
     Ensure that multiple license type filters interact together correctly.
     """
-    commercial = {'BY', 'BY-SA', 'BY-ND', 'CC0', 'PDM'}
-    modification = {'BY', 'BY-SA', 'BY-NC', 'BY-NC-SA', 'CC0', 'PDM'}
+    commercial = LICENSE_GROUPS['commercial']
+    modification = LICENSE_GROUPS['modification']
     commercial_and_modification = set.intersection(modification, commercial)
     response = requests.get(
         API_URL + '/image/search?q=a&lt=commercial,modification', verify=False
@@ -148,7 +149,7 @@ def test_license_type_filtering():
 
 
 def test_single_license_type_filtering():
-    commercial = {'BY', 'BY-SA', 'BY-ND', 'CC0', 'PDM'}
+    commercial = LICENSE_GROUPS['commercial']
     response = requests.get(
         API_URL + '/image/search?q=a&lt=commercial', verify=False
     )

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -130,3 +130,17 @@ def test_list_delete(test_list_create):
         verify=False
     )
     assert response.status_code == 204
+
+def test_license_type_filtering():
+    """
+    Ensure that multiple license type filters interact together correctly.
+    """
+    commercial = {'BY', 'BY-SA', 'BY-ND', 'CC0', 'PDM'}
+    modification = {'BY', 'BY-SA', 'BY-NC', 'BY-NC-SA', 'CC0', 'PDM'}
+    commercial_and_modification = set.intersection(modification, commercial)
+    response = requests.get(
+        API_URL + '/image/search?q=a&lt=commercial,modification'
+    )
+    parsed = json.loads(response.text)
+    for result in parsed['results']:
+        assert result['license'].upper() in commercial_and_modification

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -140,7 +140,7 @@ def test_license_type_filtering():
     modification = {'BY', 'BY-SA', 'BY-NC', 'BY-NC-SA', 'CC0', 'PDM'}
     commercial_and_modification = set.intersection(modification, commercial)
     response = requests.get(
-        API_URL + '/image/search?q=a&lt=commercial,modification'
+        API_URL + '/image/search?q=a&lt=commercial,modification', verify=False
     )
     parsed = json.loads(response.text)
     for result in parsed['results']:
@@ -149,14 +149,16 @@ def test_license_type_filtering():
 
 def test_single_license_type_filtering():
     commercial = {'BY', 'BY-SA', 'BY-ND', 'CC0', 'PDM'}
-    response = requests.get(API_URL + '/image/search?q=a&lt=commercial')
+    response = requests.get(
+        API_URL + '/image/search?q=a&lt=commercial', verify=False
+    )
     parsed = json.loads(response.text)
     for result in parsed['results']:
         assert result['license'].upper() in commercial
 
 
 def test_specific_license_filter():
-    response = requests.get(API_URL + '/image/search?q=a&li=by')
+    response = requests.get(API_URL + '/image/search?q=a&li=by', verify=False)
     parsed = json.loads(response.text)
     for result in parsed['results']:
         assert result['license'] == 'by'

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -131,6 +131,7 @@ def test_list_delete(test_list_create):
     )
     assert response.status_code == 204
 
+
 def test_license_type_filtering():
     """
     Ensure that multiple license type filters interact together correctly.
@@ -144,3 +145,11 @@ def test_license_type_filtering():
     parsed = json.loads(response.text)
     for result in parsed['results']:
         assert result['license'].upper() in commercial_and_modification
+
+
+def test_single_license_type_filtering():
+    commercial = {'BY', 'BY-SA', 'BY-ND', 'CC0', 'PDM'}
+    response = requests.get(API_URL + '/image/search?q=a&lt=commercial')
+    parsed = json.loads(response.text)
+    for result in parsed['results']:
+        assert result['license'].upper() in commercial


### PR DESCRIPTION
- Add CC0 to 'all-cc' license type
- Correctly interpret multiple license types to better match user expectations. Specifying `commercial,modification` should return results where commercial AND modification is allowed, not commercial OR modification.