### PR TITLE
Add available attribution information to API response.

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -70,14 +70,12 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
     # Search either by generic multimatch or by "advanced search" with
     # individual field-level queries specified.
     if 'q' in search_params.data:
-        keywords = ' '.join(search_params.data['q'].lower().split(','))
         s = s.query(
             'constant_score',
             filter=Q(
-                'multi_match',
-                query=keywords,
+                'query_string',
+                query=search_params.data['q'],
                 fields=['tags.name', 'title'],
-                operator='AND'
             )
         )
     else:
@@ -85,21 +83,21 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
             creator = search_params.data['creator']
             s = s.query(
                 'constant_score',
-                filter=Q('match', creator=creator)
+                filter=Q('query_string', query=creator, default_field='creator')
             )
         if 'title' in search_params.data:
             title = search_params.data['title']
             s = s.query(
                 'constant_score',
-                filter=Q('match', title=title)
+                filter=Q('query_string', query=title, default_field='title')
             )
         if 'tags' in search_params.data:
-            tags = ' '.join(search_params.data['tags'].lower().split(','))
+            tags = search_params.data['tags']
             s = s.query(
                 'constant_score',
                 filter=Q(
-                    'multi_match',
-                    fields=['tags.name'],
+                    'query_string',
+                    default_field='tags.name',
                     query=tags
                 )
             )

--- a/cccatalog-api/cccatalog/api/licenses.py
+++ b/cccatalog-api/cccatalog/api/licenses.py
@@ -20,3 +20,8 @@ LICENSE_GROUPS = {
     # All licenses allowing modifications
     "modification": {'BY', 'BY-SA', 'BY-NC', 'BY-NC-SA', 'CC0', 'PDM'},
 }
+
+ATTRIBUTION = \
+    "{title} {creator}is licensed under CC-{_license} {version}. To view a " \
+    "copy of this license, visit {license_url}."
+LICENSE_URL = 'https://creativecommons.org/licenses/{_license}/{version}/'

--- a/cccatalog-api/cccatalog/api/models.py
+++ b/cccatalog-api/cccatalog/api/models.py
@@ -1,7 +1,8 @@
 from uuslug import uuslug
 from django.db import models
 from django.utils.safestring import mark_safe
-from django.contrib.postgres.fields import JSONField, ArrayField
+from django.contrib.postgres.fields import JSONField
+from cccatalog.api.licenses import ATTRIBUTION, LICENSE_URL
 
 
 class OpenLedgerModel(models.Model):
@@ -100,6 +101,36 @@ class Image(OpenLedgerModel):
     view_count = models.IntegerField(default=0)
 
     watermarked = models.NullBooleanField(blank=True, null=True)
+
+    @property
+    def license_url(self):
+        _license = str(self.license)
+        license_version = str(self.license_version)
+        return LICENSE_URL.format(
+            _license=_license,
+            version=license_version
+        )
+
+    @property
+    def attribution(self):
+        _license = str(self.license)
+        license_version = str(self.license_version)
+        if self.title:
+            title = '"' + str(self.title) + '"'
+        else:
+            title = 'This work'
+        if self.creator:
+            creator = 'by ' + str(self.creator) + ' '
+        else:
+            creator = ''
+        attribution = ATTRIBUTION.format(
+            title=title,
+            creator=creator,
+            _license=_license.upper(),
+            version=license_version,
+            license_url=str(self.license_url)
+        )
+        return attribution
 
     def image_tag(self):
         return mark_safe('<img src="%s" width="150" />' % self.url)

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -32,13 +32,13 @@ class ImageDetailSerializer(ModelSerializer, ImageSerializer):
         help_text="The number of times that an image has been viewed. "
     )
     attribution = serializers.CharField(
-        required=False,
+        required=True,
         help_text="The Creative Commons attribution of the work. Use this to "
                   "give credit to creators to their works and fulfill "
                   "legal attribution requirements."
     )
     license_url = serializers.URLField(
-        required=False,
+        required=True,
         help_text="The URL leading to the license associated with the work."
     )
     tags = ImageDetailTagSerializer(

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -31,6 +31,16 @@ class ImageDetailSerializer(ModelSerializer, ImageSerializer):
         required=False,
         help_text="The number of times that an image has been viewed. "
     )
+    attribution = serializers.CharField(
+        required=False,
+        help_text="The Creative Commons attribution of the work. Use this to "
+                  "give credit to creators to their works and fulfill "
+                  "legal attribution requirements."
+    )
+    license_url = serializers.URLField(
+        required=False,
+        help_text="The URL leading to the license associated with the work."
+    )
     tags = ImageDetailTagSerializer(
         many=True,
         help_text="Tags with detailed metadata, such as accuracy and provider."
@@ -50,4 +60,4 @@ class ImageDetailSerializer(ModelSerializer, ImageSerializer):
         fields = ('title', 'id', 'creator', 'creator_url', 'tags',
                   'url', 'thumbnail', 'provider', 'source', 'license',
                   'license_version', 'foreign_landing_url', 'meta_data',
-                  'view_count', 'provider_url')
+                  'view_count', 'provider_url', 'license_url', 'attribution')

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -46,9 +46,12 @@ def _add_protocol(url: str):
 
 class SearchImages(APIView):
     """
-    Search for images by keyword. Optionally, filter the results by specific
+    Search for images by a query string. Optionally, filter results by specific
     licenses, or license "types" (commercial use allowed, modification allowed,
     etc). Results are ranked in order of relevance.
+
+    Refer to the Lucene syntax guide for information on structuring advanced
+    searches. https://lucene.apache.org/core/2_9_4/queryparsersyntax.html
 
     Although there may be millions of relevant records, only the most relevant
     several thousand records can be viewed. This is by design: the search

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -13,6 +13,7 @@ from cccatalog.api.serializers.search_serializers import\
 from cccatalog.api.serializers.image_serializers import ImageDetailSerializer
 from cccatalog.settings import THUMBNAIL_PROXY_URL, PROXY_THUMBS, PROXY_ALL
 from cccatalog.api.utils.view_count import _get_user_ip
+from cccatalog.api.licenses import ATTRIBUTION, LICENSE_URL
 import cccatalog.api.controllers.search_controller as search_controller
 import logging
 from urllib.parse import urlparse
@@ -29,6 +30,10 @@ THUMBNAIL = 'thumbnail'
 URL = 'url'
 THUMBNAIL_WIDTH_PX = 600
 PROVIDER = 'provider'
+LICENSE = 'license'
+LICENSE_VERSION = 'license_version'
+TITLE = 'title'
+CREATOR = 'creator'
 
 
 def _add_protocol(url: str):
@@ -176,6 +181,31 @@ class ImageDetail(GenericAPIView, RetrieveModelMixin):
         """ Get the details of a single list. """
 
         resp = self.retrieve(request, identifier)
+        # Generate attribution information
+        _license = resp.data[LICENSE].lower()
+        license_version = str(resp.data[LICENSE_VERSION])
+        license_url = LICENSE_URL.format(
+            _license=_license,
+            version=license_version
+        )
+        try:
+            title = '"' + resp.data[TITLE] + '"'
+        except KeyError:
+            title = 'This work'
+        try:
+            creator = 'by ' + resp.data[CREATOR] + ' '
+        except (KeyError, TypeError):
+            creator = ''
+        attribution = ATTRIBUTION.format(
+            title=title,
+            creator=creator,
+            _license=_license.upper(),
+            version=license_version,
+            license_url=license_url
+        )
+        resp.data['attribution'] = attribution
+        resp.data['license_url'] = license_url
+
         # Get pretty display name for a provider
         provider = resp.data[PROVIDER]
         try:

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -13,7 +13,6 @@ from cccatalog.api.serializers.search_serializers import\
 from cccatalog.api.serializers.image_serializers import ImageDetailSerializer
 from cccatalog.settings import THUMBNAIL_PROXY_URL, PROXY_THUMBS, PROXY_ALL
 from cccatalog.api.utils.view_count import _get_user_ip
-from cccatalog.api.licenses import ATTRIBUTION, LICENSE_URL
 import cccatalog.api.controllers.search_controller as search_controller
 import logging
 from urllib.parse import urlparse
@@ -30,10 +29,6 @@ THUMBNAIL = 'thumbnail'
 URL = 'url'
 THUMBNAIL_WIDTH_PX = 600
 PROVIDER = 'provider'
-LICENSE = 'license'
-LICENSE_VERSION = 'license_version'
-TITLE = 'title'
-CREATOR = 'creator'
 
 
 def _add_protocol(url: str):

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -181,31 +181,6 @@ class ImageDetail(GenericAPIView, RetrieveModelMixin):
         """ Get the details of a single list. """
 
         resp = self.retrieve(request, identifier)
-        # Generate attribution information
-        _license = resp.data[LICENSE].lower()
-        license_version = str(resp.data[LICENSE_VERSION])
-        license_url = LICENSE_URL.format(
-            _license=_license,
-            version=license_version
-        )
-        try:
-            title = '"' + resp.data[TITLE] + '"'
-        except KeyError:
-            title = 'This work'
-        try:
-            creator = 'by ' + resp.data[CREATOR] + ' '
-        except (KeyError, TypeError):
-            creator = ''
-        attribution = ATTRIBUTION.format(
-            title=title,
-            creator=creator,
-            _license=_license.upper(),
-            version=license_version,
-            license_url=license_url
-        )
-        resp.data['attribution'] = attribution
-        resp.data['license_url'] = license_url
-
         # Get pretty display name for a provider
         provider = resp.data[PROVIDER]
         try:

--- a/cccatalog-api/pytest.ini
+++ b/cccatalog-api/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = cccatalog.settings

--- a/cccatalog-api/requirements.txt
+++ b/cccatalog-api/requirements.txt
@@ -35,3 +35,4 @@ grequests
 django-sslserver
 remote-pdb
 pycodestyle
+pytest-django

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import os
 from cccatalog.api.licenses import LICENSE_GROUPS
+from cccatalog.api.models import Image
 
 """
 End-to-end API tests. Can be used to verify a live deployment is functioning as
@@ -188,3 +189,45 @@ def test_creator_quotation_grouping():
     # Monet sneak into the results?
     for result in quotes['results']:
         assert result['creator'] == 'Claude Monet'
+
+
+def test_attribution():
+    """
+    The API includes an attribution string. Since there are some works where
+    the title or creator is not known, the format of the attribution string
+    can need to be tweaked slightly.
+    """
+    title_and_creator_missing = Image(
+        identifier="ab80dbe1-414c-4ee8-9543-f9599312aeb8",
+        title=None,
+        creator=None,
+        license="by",
+        license_version="3.0"
+    )
+    print('\nAttribution examples:\n')
+    print(title_and_creator_missing.attribution)
+    assert "This work" in title_and_creator_missing.attribution
+
+    title = "A foo walks into a bar"
+    creator_missing = Image(
+        identifier="ab80dbe1-414c-4ee8-9543-f9599312aeb8",
+        title=title,
+        creator=None,
+        license="by",
+        license_version="3.0"
+    )
+    print(creator_missing.attribution)
+    assert title in creator_missing.attribution
+    assert "by " not in creator_missing.attribution
+
+    creator = "John Doe"
+    title_missing = Image(
+        identifier="ab80dbe1-414c-4ee8-9543-f9599312aeb8",
+        title=None,
+        creator=creator,
+        license="by",
+        license_version="3.0"
+    )
+    print(title_missing.attribution)
+    assert creator in title_missing.attribution
+    assert "This work" in title_missing.attribution

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -231,3 +231,14 @@ def test_attribution():
     print(title_missing.attribution)
     assert creator in title_missing.attribution
     assert "This work" in title_missing.attribution
+
+    all_data_present = Image(
+        identifier="ab80dbe1-414c-4ee8-9543-f9599312aeb8",
+        title=title,
+        creator=creator,
+        license="by",
+        license_version="3.0"
+    )
+    print(all_data_present.attribution)
+    assert title in all_data_present.attribution
+    assert creator in all_data_present.attribution

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -163,3 +163,28 @@ def test_specific_license_filter():
     parsed = json.loads(response.text)
     for result in parsed['results']:
         assert result['license'] == 'by'
+
+
+def test_creator_quotation_grouping():
+    """
+    Users should be able to group terms together with quotation marks to narrow
+    down their searches more effectively.
+    """
+    no_quotes = json.loads(
+        requests.get(
+            API_URL + '/image/search?creator=claude%20monet',
+            verify=False
+        ).text
+    )
+    quotes = json.loads(
+        requests.get(
+            API_URL + '/image/search?creator="claude%20monet"',
+            verify=False
+        ).text
+    )
+    # Did quotation marks actually narrow down the search?
+    assert len(no_quotes['results']) > len(quotes['results'])
+    # Did we find only Claude Monet works, or did his lesser known brother Jim
+    # Monet sneak into the results?
+    for result in quotes['results']:
+        assert result['creator'] == 'Claude Monet'


### PR DESCRIPTION
- Add attribution field to response. Example:
```
{
    "attribution": "\"Dish\" by A. Douglas Nash Corporation is licensed under CC-BY 3.0. To view a copy of this license, visit https://creativecommons.o
rg/licenses/by/3.0/.", 
...
}
```
- Add `license_url` field to image detail response.