### PR TITLE
#112: Exclude results with removed_from_source set to True

### DIFF
--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType, Boolean
+from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType
 
 
 class SyncableDocType(DocType):
@@ -42,7 +42,6 @@ class Image(SyncableDocType):
     foreign_landing_url = Keyword()
     meta_data = Nested()
     view_count = Integer()
-    removed_from_source = Boolean()
 
     class Index:
         name = 'image'
@@ -79,7 +78,6 @@ class Image(SyncableDocType):
             license_version=row[schema['license_version']],
             foreign_landing_url=row[schema['foreign_landing_url']],
             meta_data=None,
-            removed_from_source=row[schema['removed_from_source']],
             view_count=row[schema['view_count']],
         )
 

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType
+from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType, Boolean
 
 
 class SyncableDocType(DocType):
@@ -42,6 +42,7 @@ class Image(SyncableDocType):
     foreign_landing_url = Keyword()
     meta_data = Nested()
     view_count = Integer()
+    removed_from_source = Boolean()
 
     class Index:
         name = 'image'
@@ -78,6 +79,7 @@ class Image(SyncableDocType):
             license_version=row[schema['license_version']],
             foreign_landing_url=row[schema['foreign_landing_url']],
             meta_data=None,
+            removed_from_source=row[schema['removed_from_source']],
             view_count=row[schema['view_count']],
         )
 

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -396,7 +396,8 @@ class TableIndexer:
             converted = converted.to_dict(include_meta=True)
             if dest_index:
                 converted['_index'] = dest_index
-            documents.append(converted)
+            if not converted['removed_from_source']:
+                documents.append(converted)
 
         return documents
 

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -392,11 +392,11 @@ class TableIndexer:
 
         documents = []
         for row in pg_chunk:
-            converted = model.database_row_to_elasticsearch_doc(row, schema)
-            converted = converted.to_dict(include_meta=True)
-            if dest_index:
-                converted['_index'] = dest_index
-            if not converted['removed_from_source']:
+            if not row[schema['removed_from_source']]:
+                converted = model.database_row_to_elasticsearch_doc(row, schema)
+                converted = converted.to_dict(include_meta=True)
+                if dest_index:
+                    converted['_index'] = dest_index
                 documents.append(converted)
 
         return documents

--- a/ingestion_server/test/integration_tests.py
+++ b/ingestion_server/test/integration_tests.py
@@ -21,7 +21,7 @@ copied and indexed downstream.
 
 this_dir = os.path.dirname(__file__)
 local_ingestion_server = 'http://localhost:60002'
-ENABLE_DETAILED_LOGS = False
+ENABLE_DETAILED_LOGS = True
 
 
 def _get_host_ip():
@@ -235,7 +235,33 @@ class TestIngestion(unittest.TestCase):
         resp_json = resp.json()
         msg = 'There should be one task in the task list now.'
         self.assertEqual(1, len(resp_json), msg)
+    
+    def test05_removed_from_source_not_indexed(self):
+        id_to_check = 12119388  #Max of existing ids + 1
+        es = Elasticsearch(
+            host='localhost',
+            port=60001,
+            connection_class=RequestsHttpConnection,
+            timeout=10,
+            max_retries=10,
+            retry_on_timeout=True,
+            http_auth=None,
+            wait_for_status='yellow'
+        )
+        es_query = {
+            "query": {
+                "match_all": {}
+            }
+        }
+        es.indices.refresh(index='image')
+        search_response = es.search(
+            index="image",
+            body=es_query
+        )
 
+        ids = [hit['_id'] for hit in search_response['hits']['hits']]
+        msg = "id {} has removed from source set to False, hence it should not show up in search results."
+        self.assertNotIn(id_to_check, ids, msg)
 
 if __name__ == '__main__':
     log_level = logging.INFO if ENABLE_DETAILED_LOGS else logging.CRITICAL

--- a/ingestion_server/test/integration_tests.py
+++ b/ingestion_server/test/integration_tests.py
@@ -260,7 +260,7 @@ class TestIngestion(unittest.TestCase):
         )
 
         ids = [hit['_id'] for hit in search_response['hits']['hits']]
-        msg = "id {} has removed from source set to False, hence it should not show up in search results."
+        msg = "id {} has removed from source set to False, hence it should not show up in search results.".format(id_to_check)
         self.assertNotIn(id_to_check, ids, msg)
 
 if __name__ == '__main__':

--- a/ingestion_server/test/integration_tests.py
+++ b/ingestion_server/test/integration_tests.py
@@ -237,7 +237,7 @@ class TestIngestion(unittest.TestCase):
         self.assertEqual(1, len(resp_json), msg)
     
     def test05_removed_from_source_not_indexed(self):
-        id_to_check = 12119388  #Max of existing ids + 1
+        id_to_check = 10494466  #Index for which we changed manually False to True
         es = Elasticsearch(
             host='localhost',
             port=60001,

--- a/ingestion_server/test/integration_tests.py
+++ b/ingestion_server/test/integration_tests.py
@@ -250,7 +250,9 @@ class TestIngestion(unittest.TestCase):
         )
         es_query = {
             "query": {
-                "match_all": {}
+                "match": {
+                    "_id": id_to_check
+                }
             }
         }
         es.indices.refresh(index='image')
@@ -259,9 +261,9 @@ class TestIngestion(unittest.TestCase):
             body=es_query
         )
 
-        ids = [hit['_id'] for hit in search_response['hits']['hits']]
-        msg = "id {} has removed from source set to False, hence it should not show up in search results.".format(id_to_check)
-        self.assertNotIn(id_to_check, ids, msg)
+        num_hits = search_response['hits']['total']
+        msg = "id {} should not show up in search results.".format(id_to_check)
+        self.assertEqual(0, num_hits, msg)
 
 if __name__ == '__main__':
     log_level = logging.INFO if ENABLE_DETAILED_LOGS else logging.CRITICAL


### PR DESCRIPTION
Addressing #112, this PR adds in:
1. an explicit `removed_from_source` field during the `Image` elastic_search_model setup/
2. A check to see if the `removed_from_source` field is `False` and then only append to documents.

Things to add:
1. Test to check for the same.

@aldenstpage: Would love to hear your thoughts on this.
