### PR TITLE
Add metadata for CC Open Source site.

### DIFF
--- a/.cc-metadata.yml
+++ b/.cc-metadata.yml
@@ -1,0 +1,8 @@
+# Whether this GitHub repo is engineering related
+engineering_project: true
+# Name of the repository/project in English
+name: CC Catalog API
+# All technologies used
+technologies: Python, Django, Django REST Framework, Elasticsearch
+# Whether this repository should be featured on the CC Open Source site
+featured: true


### PR DESCRIPTION
Add metadata file to display this repo as a "featured" repo on the CC Open Source site (feature still in progress).