### PR TITLE
Disable /list endpoints #231

### DIFF
--- a/cccatalog-api/cccatalog/urls.py
+++ b/cccatalog-api/cccatalog/urls.py
@@ -77,8 +77,8 @@ urlpatterns = [
         r'^oauth2/',
         include('oauth2_provider.urls', namespace='oauth2_provider')
     ),
-    path('list', CreateList.as_view()),
-    path('list/<str:slug>', ListDetail.as_view(), name='list-detail'),
+    # path('list', CreateList.as_view()),
+    # path('list/<str:slug>', ListDetail.as_view(), name='list-detail'),
     re_path('image/search', SearchImages.as_view()),
     path('image/<str:identifier>', ImageDetail.as_view(), name='image-detail'),
     path('statistics/image', ImageStats.as_view(), name='about-image'),


### PR DESCRIPTION
The list endpoints are being retired because they aren't very useful in their current state, mostly due to the decision to implement them anonymously