### PR TITLE
Prevent PIL from destroying exif metadata when we watermark images #238

### DIFF
--- a/cccatalog-api/Dockerfile
+++ b/cccatalog-api/Dockerfile
@@ -6,4 +6,5 @@ RUN mkdir /cccatalog-api
 RUN mkdir -p /var/log/cccatalog-api/cccatalog-api.log
 WORKDIR /cccatalog-api
 ADD requirements.txt /cccatalog-api/
+ADD cccatalog/api/utils/fonts/SourceSansPro-Bold.ttf /usr/share/fonts/truetype/SourceSansPro-Bold.ttf
 RUN pip install -r requirements.txt

--- a/cccatalog-api/cccatalog/api/utils/watermark.py
+++ b/cccatalog-api/cccatalog/api/utils/watermark.py
@@ -57,7 +57,12 @@ def _full_license(image_info):
 def _print_attribution_for_image_on_frame(image_info, image, frame):
     vertical_margin_to_image = 16  # vertical margin between image and text
 
-    font = ImageFont.truetype('SourceSansPro-Bold.ttf', size=18)
+    try:
+        font = ImageFont.truetype('SourceSansPro-Bold.ttf', size=18)
+    except OSError:
+        # If we can't find the font, just fall back to the default.
+        # This path should only be hit in CI tests.
+        font = None
     draw = ImageDraw.Draw(frame)
     text_position_x = int(horizontal_margin / 2)
     text_position_y = \

--- a/cccatalog-api/cccatalog/api/utils/watermark.py
+++ b/cccatalog-api/cccatalog/api/utils/watermark.py
@@ -1,4 +1,5 @@
 import requests
+import piexif
 from io import BytesIO
 from PIL import Image, ImageFont, ImageDraw
 
@@ -12,7 +13,11 @@ def _open_image(url):
     try:
         response = requests.get(url)
         img = Image.open(BytesIO(response.content))
-        return img
+        if 'exif' in img.info:
+            exif = piexif.load(img.info['exif'])
+        else:
+            exif = None
+        return img, exif
     except requests.exceptions.RequestException:
         print('Error loading image data')
 
@@ -72,14 +77,14 @@ def _print_attribution_for_image_on_frame(image_info, image, frame):
 
 def watermark(image_url, info):
     """
-    Returns a PIL frame with the watermarked image.
+    Returns a PIL Image with a watermark and embedded metadata.
 
     :param image_url: The URL of the image.
     :param info: A dictionary with keys title, creator, license, and
     license_version
-    :returns: A PIL frame
+    :returns: A PIL Image and its EXIF data, if included.
     """
-    img = _open_image(image_url)
+    img, exif = _open_image(image_url)
     frame = _place_image_inside_frame(img)
     _print_attribution_for_image_on_frame(info, img, frame)
-    return frame
+    return frame, exif

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -18,6 +18,7 @@ from cccatalog.api.utils.watermark import watermark
 from django.http.response import HttpResponse
 import cccatalog.api.controllers.search_controller as search_controller
 import logging
+import piexif
 
 log = logging.getLogger(__name__)
 
@@ -230,7 +231,8 @@ class Watermark(GenericAPIView):
             'license': image_record.license,
             'license_version': image_record.license_version
         }
-        watermarked = watermark(image_url, image_info)
+        watermarked, exif = watermark(image_url, image_info)
+        exif_bytes = piexif.dump(exif)
         response = HttpResponse(content_type='image/jpeg')
-        watermarked.save(response, 'jpeg')
+        watermarked.save(response, 'jpeg', exif=exif_bytes)
         return response

--- a/cccatalog-api/requirements.txt
+++ b/cccatalog-api/requirements.txt
@@ -34,3 +34,4 @@ django-sslserver
 remote-pdb
 pycodestyle
 pytest-django
+piexif

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -3,8 +3,6 @@ import json
 import pytest
 import os
 import uuid
-import io
-import exifread
 from cccatalog.api.licenses import LICENSE_GROUPS
 from cccatalog.api.models import Image
 from cccatalog.api.utils.watermark import watermark

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -3,8 +3,11 @@ import json
 import pytest
 import os
 import uuid
+import io
+import exifread
 from cccatalog.api.licenses import LICENSE_GROUPS
 from cccatalog.api.models import Image
+from cccatalog.api.utils.watermark import watermark
 
 """
 End-to-end API tests. Can be used to verify a live deployment is functioning as
@@ -229,6 +232,24 @@ def test_oauth2_token_exchange(test_oauth2_registration):
         ).text
     )
     assert 'access_token' in response
+
+
+def test_watermark_preserves_exif():
+    img_with_exif = 'https://raw.githubusercontent.com/ianare/exif-samples/' \
+                    'master/jpg/Canon_PowerShot_S40.jpg'
+    info = {
+        'title': 'test',
+        'creator': 'test',
+        'license': 'test',
+        'license_version': 'test'
+    }
+    _, exif = watermark(image_url=img_with_exif, info=info)
+    assert exif is not None
+
+    img_no_exif = 'https://creativecommons.org/wp-content/uploads/' \
+                  '2019/03/9467312978_64cd5d2f3b_z.jpg'
+    _, no_exif = watermark(image_url=img_no_exif, info=info)
+    assert no_exif is None
 
 
 def test_attribution():


### PR DESCRIPTION
We use PIL to produce watermarked images. Most PIL transformations discard EXIF metadata; to work around this, extract the EXIF before we do anything to the image and add it back after the watermark has been generated.