### PR TITLE
Embed ccREL metadata into watermarked images using XMP #232

### DIFF
--- a/cccatalog-api/Dockerfile
+++ b/cccatalog-api/Dockerfile
@@ -4,6 +4,8 @@ ENV PYTHONBUFFERED 1
 
 RUN mkdir /cccatalog-api
 RUN mkdir -p /var/log/cccatalog-api/cccatalog-api.log
+RUN apt-get update
+RUN apt-get install libexempi3
 WORKDIR /cccatalog-api
 ADD requirements.txt /cccatalog-api/
 ADD cccatalog/api/utils/fonts/SourceSansPro-Bold.ttf /usr/share/fonts/truetype/SourceSansPro-Bold.ttf

--- a/cccatalog-api/cccatalog/api/utils/ccrel.py
+++ b/cccatalog-api/cccatalog/api/utils/ccrel.py
@@ -61,10 +61,8 @@ def embed_xmp_bytes(image: io.BytesIO, work_properties):
         xmp.set_property(XMP_NS_XMP_Rights, 'UsageTerms', usage)
 
         # Serialize back to io.BytesIO.
-        print(xmp)
         xmpfile.put_xmp(xmp)
         xmpfile.close_file()
-        print(xmp_temp.name)
 
     with open(filename, 'r+b') as xmpfile:
         file_with_xmp = io.BytesIO(xmpfile.read())

--- a/cccatalog-api/cccatalog/api/utils/ccrel.py
+++ b/cccatalog-api/cccatalog/api/utils/ccrel.py
@@ -1,0 +1,63 @@
+from tempfile import NamedTemporaryFile
+from libxmp.consts import XMP_NS_CC, XMP_NS_XMP_Rights
+import libxmp
+import io
+
+"""
+Tools for embedding Creative Commons Rights Expression Language (ccREL) data
+into files using Extensible Media Platform (XMP).
+
+This implementation is specifically for embedding ccREL inside of images, but it
+could be extended to handle other types of content.
+
+For more information, see the ccREL W3 standard [0].
+[0] https://www.w3.org/Submission/ccREL/
+"""
+
+
+def embed_xmp_bytes(image: io.BytesIO, work_properties):
+    """
+    Given a file-like `io.BytesIO` object, embed ccREL metadata inside of it.
+    For our purposes, we assume that the file is an image.
+
+    :param image: A BytesIO representation of an image.
+    :param work_properties: A dictionary with keys 'license_url' and
+    'attribution'. 'creator', and 'work_landing_page' are optional (but highly
+    recommended)
+    :return: An `io.BytesIO` object containing XMP metadata.
+    """
+
+    # libxmp only works with actual file locations on the disk. To work around
+    # this limitation, rather than embedding the metadata directly into the
+    # `io.BytesIO` object, we have to use a temporary file and then convert it
+    # back.
+    # https://github.com/python-xmp-toolkit/python-xmp-toolkit/issues/46
+    with NamedTemporaryFile() as xmp_temp:
+        xmp_temp.write(image.getvalue())
+        xmpfile = libxmp.XMPFiles(file_path=xmp_temp.name, open_forupdate=True)
+
+        # Set CC rights.
+        xmp = xmpfile.get_xmp()
+        xmp.register_namespace(XMP_NS_CC, 'cc')
+        xmp.set_property(XMP_NS_CC, 'license', work_properties['license_url'])
+        if 'creator' in work_properties:
+            xmp.set_property(
+                XMP_NS_CC, 'attributionName', work_properties['creator']
+            )
+        if 'work_landing_page' in work_properties:
+            xmp.set_property(
+                XMP_NS_CC,
+                'attributionURL',
+                work_properties['work_landing_page']
+            )
+        # Set generic XMP rights.
+        xmp.register_namespace(XMP_NS_XMP_Rights, 'xmpRights')
+        xmp.set_property_bool(XMP_NS_XMP_Rights, 'Marked', True)
+        usage = work_properties['attribution']
+        xmp.set_property(XMP_NS_XMP_Rights, 'UsageTerms', usage)
+
+        # Serialize back to io.BytesIO.
+        xmpfile.put_xmp(xmp)
+        xmpfile.close_file()
+        xmp_temp.seek(0)
+        return io.BytesIO(xmp_temp.read())

--- a/cccatalog-api/cccatalog/api/utils/ccrel.py
+++ b/cccatalog-api/cccatalog/api/utils/ccrel.py
@@ -1,5 +1,4 @@
-from tempfile import NamedTemporaryFile
-from libxmp.consts import XMP_NS_CC, XMP_NS_XMP_Rights
+from libxmp.consts import XMP_NS_CC, XMP_NS_XMP_Rights, XMP_NS_XMP
 import libxmp
 import io
 import os
@@ -7,7 +6,7 @@ import uuid
 
 """
 Tools for embedding Creative Commons Rights Expression Language (ccREL) data
-into files using Extensible Media Platform (XMP).
+into files using Extensible Metadata Platform (XMP).
 
 This implementation is specifically for embedding ccREL inside of images, but it
 could be extended to handle other types of content.
@@ -54,13 +53,18 @@ def embed_xmp_bytes(image: io.BytesIO, work_properties):
                 'attributionURL',
                 work_properties['work_landing_page']
             )
+        if 'identifier' in work_properties:
+            xmp.register_namespace(XMP_NS_XMP, 'xmp')
+            xmp.set_property(
+                XMP_NS_XMP,
+                'Identifier',
+                work_properties['identifier']
+            )
         # Set generic XMP rights.
         xmp.register_namespace(XMP_NS_XMP_Rights, 'xmpRights')
         xmp.set_property_bool(XMP_NS_XMP_Rights, 'Marked', True)
         usage = work_properties['attribution']
         xmp.set_property(XMP_NS_XMP_Rights, 'UsageTerms', usage)
-
-        # Serialize back to io.BytesIO.
         xmpfile.put_xmp(xmp)
         xmpfile.close_file()
 

--- a/cccatalog-api/cccatalog/api/utils/watermark.py
+++ b/cccatalog-api/cccatalog/api/utils/watermark.py
@@ -12,7 +12,9 @@ text_color = '#000'
 def _open_image(url):
     try:
         response = requests.get(url)
-        img = Image.open(BytesIO(response.content))
+        img_bytes = BytesIO(response.content)
+        img = Image.open(img_bytes)
+        # Preserve EXIF metadata
         if 'exif' in img.info:
             exif = piexif.load(img.info['exif'])
         else:

--- a/cccatalog-api/cccatalog/api/utils/watermark.py
+++ b/cccatalog-api/cccatalog/api/utils/watermark.py
@@ -18,7 +18,7 @@ def _open_image(url):
         if 'exif' in img.info:
             exif = piexif.load(img.info['exif'])
         else:
-            exif = None
+            exif = {}
         return img, exif
     except requests.exceptions.RequestException:
         print('Error loading image data')

--- a/cccatalog-api/cccatalog/api/utils/watermark.py
+++ b/cccatalog-api/cccatalog/api/utils/watermark.py
@@ -18,7 +18,7 @@ def _open_image(url):
         if 'exif' in img.info:
             exif = piexif.load(img.info['exif'])
         else:
-            exif = {}
+            exif = None
         return img, exif
     except requests.exceptions.RequestException:
         print('Error loading image data')

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -246,16 +246,18 @@ class Watermark(GenericAPIView):
             'license_url': image_record.license_url,
             'attribution': image_record.attribution,
             'work_landing_page': image_record.foreign_landing_url,
+            'identifier': str(image_record.identifier)
         }
         try:
             with_xmp = ccrel.embed_xmp_bytes(img_bytes, work_properties)
             return FileResponse(with_xmp, content_type='image/jpeg')
-        except (libxmp.XMPError, AttributeError):
+        except (libxmp.XMPError, AttributeError) as e:
             # Just send the EXIF-ified file if libxmp fails to add metadata.
             log.error(
                 'Failed to add XMP metadata to {}'
                 .format(image_record.identifier)
             )
+            log.error(e)
             response = HttpResponse(content_type='image/jpeg')
             watermarked.save(response, 'jpeg', exif=exif_bytes)
             return response

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -16,7 +16,7 @@ from cccatalog.settings import THUMBNAIL_PROXY_URL, PROXY_THUMBS, PROXY_ALL
 from cccatalog.api.utils.view_count import _get_user_ip
 from urllib.parse import urlparse
 from cccatalog.api.utils.watermark import watermark
-from django.http.response import HttpResponse
+from django.http.response import HttpResponse, FileResponse
 import cccatalog.api.controllers.search_controller as search_controller
 import logging
 import piexif
@@ -249,8 +249,9 @@ class Watermark(GenericAPIView):
         }
         try:
             with_xmp = ccrel.embed_xmp_bytes(img_bytes, work_properties)
-            return HttpResponse(with_xmp.getvalue(), content_type='image/jpeg')
+            return FileResponse(with_xmp, content_type='image/jpeg')
         except (libxmp.XMPError, AttributeError):
+            # Just send the EXIF-ified file if libxmp fails to add metadata.
             log.error(
                 'Failed to add XMP metadata to {}'
                 .format(image_record.identifier)

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -6,6 +6,7 @@ from drf_yasg.utils import swagger_auto_schema
 from cccatalog.api.models import Image, ContentProvider
 from cccatalog.api.utils.validate_images import validate_images
 from cccatalog.api.utils.view_count import track_model_views
+from cccatalog.api.utils import ccrel
 from rest_framework.reverse import reverse
 from cccatalog.api.serializers.search_serializers import\
     ImageSearchResultsSerializer, ImageSerializer,\
@@ -19,6 +20,8 @@ from django.http.response import HttpResponse
 import cccatalog.api.controllers.search_controller as search_controller
 import logging
 import piexif
+import io
+import libxmp
 
 log = logging.getLogger(__name__)
 
@@ -231,8 +234,27 @@ class Watermark(GenericAPIView):
             'license': image_record.license,
             'license_version': image_record.license_version
         }
+        # Create the actual watermarked image.
         watermarked, exif = watermark(image_url, image_info)
+        # Re-insert EXIF metadata.
         exif_bytes = piexif.dump(exif)
-        response = HttpResponse(content_type='image/jpeg')
-        watermarked.save(response, 'jpeg', exif=exif_bytes)
-        return response
+        img_bytes = io.BytesIO()
+        watermarked.save(img_bytes, 'jpeg', exif=exif_bytes)
+        # Embed ccREL metadata with XMP.
+        work_properties = {
+            'creator': image_record.creator,
+            'license_url': image_record.license_url,
+            'attribution': image_record.attribution,
+            'work_landing_page': image_record.foreign_landing_url,
+        }
+        try:
+            with_xmp = ccrel.embed_xmp_bytes(img_bytes, work_properties)
+            return HttpResponse(with_xmp.getvalue(), content_type='image/jpeg')
+        except (libxmp.XMPError, AttributeError):
+            log.error(
+                'Failed to add XMP metadata to {}'
+                .format(image_record.identifier)
+            )
+            response = HttpResponse(content_type='image/jpeg')
+            watermarked.save(response, 'jpeg', exif=exif_bytes)
+            return response

--- a/cccatalog-api/requirements.txt
+++ b/cccatalog-api/requirements.txt
@@ -35,3 +35,4 @@ remote-pdb
 pycodestyle
 pytest-django
 piexif
+python-xmp-toolkit


### PR DESCRIPTION
Related to #232. I added embedded ccREL through XMP to watermarked images. Here's an example of the raw XML:
```
web_1               | <?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
web_1               | <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Exempi + XMP Core 5.5.0">
web_1               |  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
web_1               |   <rdf:Description rdf:about=""
web_1               |     xmlns:tiff="http://ns.adobe.com/tiff/1.0/"
web_1               |     xmlns:xmp="http://ns.adobe.com/xap/1.0/"
web_1               |     xmlns:exif="http://ns.adobe.com/exif/1.0/"
web_1               |     xmlns:cc="http://creativecommons.org/ns#"
web_1               |     xmlns:xmpRights="http://ns.adobe.com/xap/1.0/rights/">
web_1               |    <tiff:Orientation>1</tiff:Orientation>
web_1               |    <tiff:XResolution>3000000/10000</tiff:XResolution>
web_1               |    <tiff:YResolution>3000000/10000</tiff:YResolution>
web_1               |    <tiff:ResolutionUnit>2</tiff:ResolutionUnit>
web_1               |    <xmp:CreatorTool>Adobe Photoshop CS6 (Windows)</xmp:CreatorTool>
web_1               |    <xmp:ModifyDate>2016-12-28T18:28:51</xmp:ModifyDate>
web_1               |    <exif:ColorSpace>1</exif:ColorSpace>
web_1               |    <exif:PixelXDimension>2613</exif:PixelXDimension>
web_1               |    <exif:PixelYDimension>1742</exif:PixelYDimension>
web_1               |    <cc:license>https://creativecommons.org/licenses/by-nc-nd/4.0/</cc:license>
web_1               |    <cc:attributionName>Irina Kurnosenko</cc:attributionName>
web_1               |    <cc:attributionURL>https://www.behance.net/gallery/47190347/Illustrations-for-the-Christmas-test</cc:attributionURL>
web_1               |    <xmpRights:Marked>True</xmpRights:Marked>
web_1               |    <xmpRights:UsageTerms>"Illustrations for the Christmas test" by Irina Kurnosenko is licensed under CC-BY-NC-ND 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-nd/4.0/.</xmpRights:UsageTerms>
web_1               |   </rdf:Description>
web_1               |  </rdf:RDF>
web_1               | </x:xmpmeta>
web_1               | <?xpacket end="w"?>
```

...and here's what the attribution metadata looks like from `exiftool`. This includes both EXIF and XMP metadata.
```
alden@cc-laptop:~/Downloads$ exiftool -a 10.jpeg
ExifTool Version Number         : 10.40
File Name                       : 10.jpeg
Directory                       : .
File Size                       : 79 kB
File Modification Date/Time     : 2019:03:15 18:00:37-04:00
File Access Date/Time           : 2019:03:15 18:00:41-04:00
File Inode Change Date/Time     : 2019:03:15 18:00:37-04:00
File Permissions                : rw-r--r--
File Type                       : JPEG
File Type Extension             : jpg
MIME Type                       : image/jpeg
JFIF Version                    : 1.01
Resolution Unit                 : None
X Resolution                    : 1
Y Resolution                    : 1
Exif Byte Order                 : Big-endian (Motorola, MM)
Orientation                     : Horizontal (normal)
X Resolution                    : 300
Y Resolution                    : 300
Resolution Unit                 : inches
Software                        : Adobe Photoshop CS6 (Windows)
Modify Date                     : 2016:12:28 18:28:51
Color Space                     : sRGB
Exif Image Width                : 2613
Exif Image Height               : 1742
Compression                     : JPEG (old-style)
X Resolution                    : 72
Y Resolution                    : 72
Resolution Unit                 : inches
Thumbnail Offset                : 326
Thumbnail Length                : 2761
XMP Toolkit                     : Exempi + XMP Core 5.5.0
Creator Tool                    : Adobe Photoshop CS6 (Windows)
Modify Date                     : 2016:12:28 18:28:51
License                         : https://creativecommons.org/licenses/by-nc-nd/4.0/
Attribution Name                : Irina Kurnosenko
Attribution URL                 : https://www.behance.net/gallery/47190347/Illustrations-for-the-Christmas-test
Marked                          : True
Usage Terms                     : "Illustrations for the Christmas test" by Irina Kurnosenko is licensed under CC-BY-NC-ND 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-nd/4.0/.
Copyright Flag                  : True
IPTC Digest                     : d41d8cd98f00b204e9800998ecf8427e
Image Width                     : 1500
Image Height                    : 1133
Encoding Process                : Baseline DCT, Huffman coding
Bits Per Sample                 : 8
Color Components                : 3
Y Cb Cr Sub Sampling            : YCbCr4:2:0 (2 2)
Image Size                      : 1500x1133
Megapixels                      : 1.7
Thumbnail Image                 : (Binary data 2761 bytes, use -b option to extract)
```