### PR TITLE
Implement cleanup module to tidy up raw data from upstream CC Catalog #244

### DIFF
--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -109,15 +109,15 @@ def clean_data(conn, table):
         where_clause = 'WHERE ' + provider_condition
 
     # Pull selected fields.
-    fields = set()
+    fields_to_clean = set()
     for p in providers:
         _fields = list(table_config['providers'][p]['fields'])
         for f in _fields:
-            fields.add(f)
+            fields_to_clean.add(f)
 
     cleanup_query = "SELECT id, provider, {fields} from {table}" \
                     " {where_clause}".format(
-                        fields=', '.join(fields),
+                        fields=', '.join(fields_to_clean),
                         table='temp_import_{}'.format(table),
                         where_clause=where_clause
                     )
@@ -130,7 +130,7 @@ def clean_data(conn, table):
     cleaned_count = 0
     provider_config = table_config['providers']
     for row in iter_cur:
-        for field in fields:
+        for field in fields_to_clean:
             row_id = row['id']
             provider = row['provider']
             to_clean = row[field]

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -93,7 +93,7 @@ def _clean_data_worker(rows, temp_table, providers_config):
         _id = row['id']
         if provider in providers_config:
             provider_field_to_func = providers_config[provider]['fields']
-            # Merge provider-local and global function to field mappings
+            # Merge provider-local and global function field mappings
             fields_to_update = \
                 {**global_field_to_func, **provider_field_to_func}
         else:
@@ -101,7 +101,6 @@ def _clean_data_worker(rows, temp_table, providers_config):
         # Map fields to their cleaned data
         cleaned_data = {}
         for update_field in fields_to_update:
-
             dirty_value = row[update_field]
             cleaning_func = fields_to_update[update_field]
             clean = cleaning_func(dirty_value)

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -179,7 +179,6 @@ def clean_data(table):
     iter_cur.execute(cleanup_selection)
 
     # Clean each field as specified in _cleanup_config.
-    cleaned_count = 0
     provider_config = table_config['providers']
 
     batch = iter_cur.fetchmany(size=DB_BUFFER_SIZE)

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -28,11 +28,6 @@ _cleanup_config = {
                     'fields': {
                         'url': _cleanup_url
                     }
-                },
-                'behance': {
-                    'fields': {
-                        'url': _cleanup_url
-                    }
                 }
             }
         }

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -212,4 +212,3 @@ def clean_data(table):
     log.info('Cleaned all records in {} seconds'.format(
         cleanup_time)
     )
-    log.info('Cleaning finished!')

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -68,8 +68,8 @@ def clean_data(conn, table):
                         fields=','.join(fields),
                         table='temp_import_{}'.format(table),
                         conditions=provider_condition
-    )
-    log.info('Running cleanup of "{}"'.format(cleanup_query))
+                    )
+    log.info('Running cleanup on selection "{}"'.format(cleanup_query))
     write_cur = conn.cursor(cursor_factory=DictCursor)
     iter_cur = conn.cursor(cursor_factory=DictCursor)
     iter_cur.execute(cleanup_query)

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -1,0 +1,101 @@
+import logging as log
+import time
+from psycopg2.extras import DictCursor
+from urllib.parse import urlparse
+
+
+def _cleanup_url(url):
+    """
+    Add protocols to the URI if they are missing, else return none.
+    :param url:
+    :return:
+    """
+    parsed = urlparse(url)
+    if parsed.scheme == '':
+        return 'https://' + url
+    else:
+        return None
+
+
+# Define which tables, providers, and fields require cleanup. Map the field
+# to a cleanup function that returns either a cleaned version of the field
+# or 'None' to signal that no update is required.
+_cleanup_config = {
+    'tables': {
+        'image': {
+            'providers': {
+                'floraon': {
+                    'fields': {
+                        'url': _cleanup_url
+                    }
+                },
+                'behance': {
+                    'fields': {
+                        'url': _cleanup_url
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+def clean_data(conn, table):
+    """
+    Data from upstream can be unsuitable for production for a number of reasons.
+    Clean it up before we go live with the new data.
+
+    :param conn: The database connection
+    :param table: The staging table for the new data
+    :return: None
+    """
+    # Map each table to the fields that need to be cleaned up. Then, map each
+    # field to its cleanup function.
+    log.info('Cleaning up data...')
+    start_time = time.time()
+
+    temporary_table = 'temp_import_{}'.format(table)
+    providers = _cleanup_config['tables'][table]['providers'].keys()
+    providers = [str(provider) for provider in providers]
+    cleaned_count = 0
+    for provider in providers:
+        cleanup_field_config = \
+            _cleanup_config['tables'][table]['providers'][provider]['fields']
+        cleanup_fields = list(cleanup_field_config.keys())
+        cleanup_query = "SELECT id, {fields} from {table}" \
+                        " where provider = '{provider}'".format(
+                            fields=','.join(cleanup_fields),
+                            table='temp_import_{}'.format(table),
+                            provider=provider
+        )
+        log.info('Running cleanup "{}"'.format(cleanup_query))
+        write_cur = conn.cursor(cursor_factory=DictCursor)
+        iter_cur = conn.cursor(cursor_factory=DictCursor)
+        iter_cur.execute(cleanup_query)
+        for row in iter_cur:
+            for field in cleanup_fields:
+                row_id = row['id']
+                to_clean = row[field]
+                cleanup_function = cleanup_field_config[field]
+                cleaned = cleanup_function(to_clean)
+                if cleaned:
+                    cleaned_count += 1
+                    update_query = '''
+                        UPDATE {temp_table} SET {field} = '{cleaned}'
+                         WHERE id = {id};
+                    '''.format(
+                        temp_table=temporary_table,
+                        field=field,
+                        cleaned=cleaned,
+                        id=row_id
+                    )
+                    write_cur.execute(update_query)
+        iter_cur.close()
+        write_cur.close()
+
+    end_time = time.time()
+    cleanup_time = end_time - start_time
+    log.info('Cleaned {} records in {} seconds'.format(
+        cleaned_count,
+        cleanup_time)
+    )

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -12,7 +12,8 @@ TAG_BLACKLIST = {
     'no person',
     'squareformat',
     'uploaded:by=flickrmobile',
-    'uploaded:by=instagram'
+    'uploaded:by=instagram',
+    'cc0'
 }
 
 # Filter out low-confidence tags, which indicate that the machine-generated tag


### PR DESCRIPTION
CC Catalog stores raw data from upstream content providers that can be inappropriate for production use. Now, every time we import data from CC Catalog, perform some cleanup of the data as we copy it into the API database. By setting values in _cleanup_config, you can have fine grained control over which fields from which providers and which tables get cleaned up.

Right now, Ingestion Server is capable of fixing malformed URLs, deleting blacklisted tags, and deleting machine generated tags whose confidence falls under a 90% threshold. Adding more cleanup functions is easy.

I think we can feasibly run this on the entire 285MM dataset. I'll have to run it in testing to be sure.

We should also switch Ingestion Server to an instance with more threads available so it can take advantage of parallel cleaning workers.

Related to #244/#245