### PR TITLE
embed_metadata and watermark parameters #243

### DIFF
--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -61,3 +61,15 @@ class ImageDetailSerializer(ModelSerializer, ImageSerializer):
                   'url', 'thumbnail', 'provider', 'source', 'license',
                   'license_version', 'foreign_landing_url', 'meta_data',
                   'view_count', 'provider_url', 'license_url', 'attribution')
+
+
+class WatermarkQueryStringSerializer(serializers.Serializer):
+    embed_metadata = serializers.BooleanField(
+        help_text="Whether to embed ccREL metadata via XMP.",
+        default=True
+    )
+    watermark = serializers.BooleanField(
+        help_text="Whether to draw a frame around the image with attribution"
+                  " text at the bottom.",
+        default=True
+    )

--- a/cccatalog-api/cccatalog/api/utils/watermark.py
+++ b/cccatalog-api/cccatalog/api/utils/watermark.py
@@ -226,16 +226,19 @@ def _print_attribution_on_image(img, image_info):
     return frame
 
 
-def watermark(image_url, info):
+def watermark(image_url, info, draw_frame=True):
     """
     Returns a PIL Image with a watermark and embedded metadata.
 
     :param image_url: The URL of the image.
     :param info: A dictionary with keys title, creator, license, and
     license_version
+    :param draw_frame: Whether to draw an attribution frame.
     :returns: A PIL Image and its EXIF data, if included.
     """
 
     img, exif = _open_image(image_url)
+    if not draw_frame:
+        return img, exif
     frame = _print_attribution_on_image(img, info)
     return frame, exif

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -11,7 +11,8 @@ from rest_framework.reverse import reverse
 from cccatalog.api.serializers.search_serializers import\
     ImageSearchResultsSerializer, ImageSerializer,\
     ValidationErrorSerializer, ImageSearchQueryStringSerializer
-from cccatalog.api.serializers.image_serializers import ImageDetailSerializer
+from cccatalog.api.serializers.image_serializers import ImageDetailSerializer,\
+    WatermarkQueryStringSerializer
 from cccatalog.settings import THUMBNAIL_PROXY_URL, PROXY_THUMBS, PROXY_ALL
 from cccatalog.api.utils.view_count import _get_user_ip
 from urllib.parse import urlparse
@@ -215,14 +216,36 @@ class ImageDetail(GenericAPIView, RetrieveModelMixin):
         return resp
 
 
+def _save_wrapper(pil_img, exif_bytes, destination):
+    """
+    PIL crashes if exif_bytes=None, so we have to wrap it to avoid littering
+    the code with branches.
+    """
+    if exif_bytes:
+        pil_img.save(destination, 'jpeg', exif=exif_bytes)
+    else:
+        pil_img.save(destination, 'jpeg')
+
+
 class Watermark(GenericAPIView):
     """
     Given an image identifier as a URL parameter, produce an attribution
-    watermark.
+    watermark. This entails drawing a frame around the image and embedding
+    ccREL metadata inside of the file.
     """
     lookup_field = 'identifier'
+    serializer_class = WatermarkQueryStringSerializer
 
+    @swagger_auto_schema(query_serializer=WatermarkQueryStringSerializer)
     def get(self, request, identifier, format=None):
+        params = WatermarkQueryStringSerializer(data=request.query_params)
+        if not params.is_valid():
+            return Response(
+                status=400,
+                data={
+                    "validation_error": params.errors
+                }
+            )
         try:
             image_record = Image.objects.get(identifier=identifier)
         except Image.DoesNotExist:
@@ -235,38 +258,39 @@ class Watermark(GenericAPIView):
             'license_version': image_record.license_version
         }
         # Create the actual watermarked image.
-        watermarked, exif = watermark(image_url, image_info)
+        watermarked, exif = watermark(
+            image_url, image_info, params.data['watermark']
+        )
         # Re-insert EXIF metadata.
         if exif:
             exif_bytes = piexif.dump(exif)
         else:
             exif_bytes = None
         img_bytes = io.BytesIO()
-        if exif:
-            watermarked.save(img_bytes, 'jpeg', exif=exif_bytes)
+        _save_wrapper(watermarked, exif_bytes, img_bytes)
+        if params.data['embed_metadata']:
+            # Embed ccREL metadata with XMP.
+            work_properties = {
+                'creator': image_record.creator,
+                'license_url': image_record.license_url,
+                'attribution': image_record.attribution,
+                'work_landing_page': image_record.foreign_landing_url,
+                'identifier': str(image_record.identifier)
+            }
+            try:
+                with_xmp = ccrel.embed_xmp_bytes(img_bytes, work_properties)
+                return FileResponse(with_xmp, content_type='image/jpeg')
+            except (libxmp.XMPError, AttributeError) as e:
+                # Just send the EXIF-ified file if libxmp fails to add metadata.
+                log.error(
+                    'Failed to add XMP metadata to {}'
+                    .format(image_record.identifier)
+                )
+                log.error(e)
+                response = HttpResponse(content_type='image/jpeg')
+                _save_wrapper(watermarked, exif_bytes, response)
+                return response
         else:
-            watermarked.save(img_bytes, 'jpeg')
-        # Embed ccREL metadata with XMP.
-        work_properties = {
-            'creator': image_record.creator,
-            'license_url': image_record.license_url,
-            'attribution': image_record.attribution,
-            'work_landing_page': image_record.foreign_landing_url,
-            'identifier': str(image_record.identifier)
-        }
-        try:
-            with_xmp = ccrel.embed_xmp_bytes(img_bytes, work_properties)
-            return FileResponse(with_xmp, content_type='image/jpeg')
-        except (libxmp.XMPError, AttributeError) as e:
-            # Just send the EXIF-ified file if libxmp fails to add metadata.
-            log.error(
-                'Failed to add XMP metadata to {}'
-                .format(image_record.identifier)
-            )
-            log.error(e)
-            response = HttpResponse(content_type='image/jpeg')
-            if exif:
-                watermarked.save(response, 'jpeg', exif=exif_bytes)
-            else:
-                watermarked.save(response, 'jpeg')
+            response = HttpResponse(img_bytes, content_type='image/jpeg')
+            _save_wrapper(watermarked, exif_bytes, response)
             return response


### PR DESCRIPTION
`embed_metadata` controls whether we embed ccREL XMP metadata inside of a watermarked image.

`watermark` controls whether the frame is drawn at all.

In situations where both embed_metadata=False and watermark=False, the caller should avoid using the endpoint and instead link directly to the image in order to save cycles on the server.