### PR TITLE
Optimize ingestion cleanup set so it scales to realistic workloads.  creativecommons/ccsearch-infrastructure#42

### DIFF
--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -240,6 +240,7 @@ def reload_upstream(table, progress=None, finish_time=None):
         CREATE TABLE temp_import_{table} (LIKE {table} INCLUDING CONSTRAINTS);
         INSERT INTO temp_import_{table} ({cols})
         SELECT {cols} from upstream_schema.{table};
+        ALTER TABLE temp_import_{table} ADD PRIMARY KEY (id);
         DROP SERVER upstream CASCADE;
     '''.format(table=table, cols=query_cols)
     create_indices = ';\n'.join(_generate_indices(downstream_db, table))


### PR DESCRIPTION
Fixes creativecommons/ccsearch-infrastructure#42.
- Set cur.itersize so psycopg2 doesn't try to load the entire table into memory at once (setting fetchmany(size=...) was not enough to prevent this)
- Set a primary key index before attempting to clean the data in the temporary table; otherwise, the time to update a single record grows linearly with the size of the table. This bug didn't come up in testing, which only has a few thousand records, but is definitely unworkable on a production-sized table.