### PR TITLE
Move from Travis to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,52 @@
+version: 2.1
+
+executors:
+  cccatalog:
+    docker:
+    - image: python:3.7
+    - image: postgres:10
+
+commands:
+  install_deps:
+    description: "Install the dependencies from Pipenv"
+    parameters:
+      directory:
+        type: string
+        default: "."
+    steps:
+      - run:
+          command: |
+            cd << parameters.directory >>
+            pipenv install --system --deploy --dev
+            cd ..
+
+jobs:
+  lint_api:
+    executor: cccatalog
+    steps:
+    - run: pip install pipenv
+    - checkout
+    - install_deps:
+        directory: "cccatalog-api"
+    - run: pycodestyle cccatalog-api/cccatalog/*.py --exclude='cccatalog-api/cccatalog/api/migrations' --max-line-length=80 --ignore=E402
+
+  lint_ingestion:
+    executor: cccatalog
+    steps:
+    - run: pip install pipenv
+    - checkout
+    - install_deps:
+        directory: "ingestion_server"
+    - run: pycodestyle ingestion_server/*.py --max-line-length=80 --ignore=E402
+
+workflows:
+  version: 2
+
+  ingestion:
+    jobs:
+    - lint_ingestion
+
+  api:
+    jobs:
+    - lint_api
+    


### PR DESCRIPTION
This PR addresses issue #265 raised by @kgodey regarding the replacement of Travis with CircleCI.

<details>
<summary>
Developer Certificate of Origin
Version 1.1
</summary>
<p>
Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</p>
</details>