### PR TITLE
Fix casing inconsistency breaking license filters for the MET

### DIFF
--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -74,7 +74,7 @@ class Image(SyncableDocType):
             thumbnail=row[schema['thumbnail']],
             provider=row[schema['provider']],
             source=row[schema['source']],
-            license=row[schema['license']],
+            license=row[schema['license']].lower(),
             license_version=row[schema['license_version']],
             foreign_landing_url=row[schema['foreign_landing_url']],
             meta_data=None,


### PR DESCRIPTION
Elasticsearch keyword matches are case sensitive, and some providers have different casing in their license (the MET has both 'cc0' and 'CC0'. Make all license types lowercase to enforce consistency.

Reindexing is required for this change to take effect. @brenoferreira fyi