### PR TITLE
Browse by provider

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -107,14 +107,13 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
     return search_response
 
 
-def browse_by_provider(search_params, index, page_size, ip, page=1):
+def browse_by_provider(provider, index, page_size, ip, page=1):
     """
-    Allow users to browse image collections without entering any search queries.
+    Allow users to browse image collections without entering a search query.
     """
     s = Search(index=index)
     s = _paginate_search(s, page_size, page)
     s = s.params(preference=str(ip))
-    provider = search_params.data['provider']
     provider_filter = Q('term', provider=provider)
     s = s.filter('bool', should=provider_filter, minimum_should_match=1)
     search_response = s.execute()

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -14,6 +14,19 @@ ELASTICSEARCH_MAX_RESULT_WINDOW = 10000
 CACHE_TIMEOUT = 10
 
 
+def _paginate_search(s: Search, page_size: int, page: int):
+    """
+    Select the start and end of the search results for this query.
+    """
+    # Paginate search query.
+    start_slice = page_size * (page - 1)
+    end_slice = page_size * page
+    if start_slice + end_slice > ELASTICSEARCH_MAX_RESULT_WINDOW:
+        raise ValueError("Deep pagination is not allowed.")
+    s = s[start_slice:end_slice]
+    return s
+
+
 def search(search_params, index, page_size, ip, page=1) -> Response:
     """
     Given a set of keywords and an optional set of filters, perform a ranked
@@ -30,13 +43,7 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
     :return: An Elasticsearch Response object.
     """
     s = Search(index=index)
-
-    # Paginate search query.
-    start_slice = page_size * (page - 1)
-    end_slice = page_size * page
-    if start_slice + end_slice > ELASTICSEARCH_MAX_RESULT_WINDOW:
-        raise ValueError("Deep pagination is not allowed.")
-    s = s[start_slice:end_slice]
+    s = _paginate_search(s, page_size, page)
 
     # If any filters are specified, add them to the query.
     if 'li' in search_params.data or 'lt' in search_params.data:
@@ -96,6 +103,20 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
 
     s.extra(track_scores=True)
     s = s.params(preference=str(ip))
+    search_response = s.execute()
+    return search_response
+
+
+def browse_by_provider(search_params, index, page_size, ip, page=1):
+    """
+    Allow users to browse image collections without entering any search queries.
+    """
+    s = Search(index=index)
+    s = _paginate_search(s, page_size, page)
+    s = s.params(preference=str(ip))
+    provider = search_params.data['provider']
+    provider_filter = Q('term', provider=provider)
+    s = s.filter('bool', should=provider_filter, minimum_should_match=1)
     search_response = s.execute()
     return search_response
 

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -37,15 +37,6 @@ class BrowseImageQueryStringSerializer(serializers.Serializer):
     )
 
     @staticmethod
-    def validate_provider(input_provider):
-        allowed_providers = list(get_providers('image').keys())
-        if input_provider not in allowed_providers:
-            raise serializers.ValidationError(
-                "Provider \'{}\' does not exist.".format(input_provider)
-            )
-        return input_provider.lower()
-
-    @staticmethod
     def validate_page(value):
         return _validate_page(value)
 

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -18,12 +18,6 @@ def _validate_pagesize(value):
 
 
 class BrowseImageQueryStringSerializer(serializers.Serializer):
-    provider = serializers.CharField(
-        label="provider",
-        help_text="The provider to browse. Valid inputs:"
-                  " `{}`".format(list(get_providers('image').keys())),
-        required=True
-    )
     page = serializers.IntegerField(
         label="page number",
         help_text="The page number to retrieve.",

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -3,6 +3,63 @@ from cccatalog.api.licenses import LICENSE_GROUPS
 from cccatalog.api.controllers.search_controller import get_providers
 
 
+def _validate_page(value):
+    if value < 1:
+        return 1
+    else:
+        return value
+
+
+def _validate_pagesize(value):
+    if 1 <= value < 500:
+        return value
+    else:
+        return 20
+
+
+class BrowseImageQueryStringSerializer(serializers.Serializer):
+    provider = serializers.CharField(
+        label="provider",
+        help_text="The provider to browse. Valid inputs:"
+                  " `{}`".format(list(get_providers('image').keys())),
+        required=True
+    )
+    page = serializers.IntegerField(
+        label="page number",
+        help_text="The page number to retrieve.",
+        default=1
+    )
+    pagesize = serializers.IntegerField(
+        label="page size",
+        help_text="The number of results to return in the requested page. "
+                  "Should be an integer between 1 and 500.",
+        default=20
+    )
+    filter_dead = serializers.BooleanField(
+        label="filter_dead",
+        help_text="Control whether 404 links are filtered out.",
+        required=False,
+        default=True
+    )
+
+    @staticmethod
+    def validate_provider(input_provider):
+        allowed_providers = list(get_providers('image').keys())
+        if input_provider not in allowed_providers:
+            raise serializers.ValidationError(
+                "Provider \'{}\' does not exist.".format(input_provider)
+            )
+        return input_provider.lower()
+
+    @staticmethod
+    def validate_page(value):
+        return _validate_page(value)
+
+    @staticmethod
+    def validate_pagesize(value):
+        return _validate_pagesize(value)
+
+
 class ImageSearchQueryStringSerializer(serializers.Serializer):
     """ Base class for search query parameters. """
 
@@ -75,7 +132,8 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
         default=False
     )
 
-    def validate_q(self, value):
+    @staticmethod
+    def validate_q(value):
         if len(value) > 200:
             return value[0:199]
         else:
@@ -90,7 +148,8 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
     def validate_title(self, value):
         return self.validate_q(value)
 
-    def validate_li(self, value):
+    @staticmethod
+    def validate_li(value):
         licenses = [x.upper() for x in value.split(',')]
         for _license in licenses:
             if _license not in LICENSE_GROUPS['all']:
@@ -99,7 +158,8 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
                 )
         return value.lower()
 
-    def validate_lt(self, value):
+    @staticmethod
+    def validate_lt(value):
         """
         Resolves a list of license types to a list of licenses.
         Example: commercial -> ['BY', 'BY-SA', 'BY-ND', 'CC0', 'PDM']
@@ -117,19 +177,16 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
 
         return ','.join(list(cleaned))
 
-    def validate_page(self, value):
-        if value < 1:
-            return 1
-        else:
-            return value
+    @staticmethod
+    def validate_page(value):
+        return _validate_page(value)
 
-    def validate_pagesize(self, value):
-        if 1 <= value < 500:
-            return value
-        else:
-            return 20
+    @staticmethod
+    def validate_pagesize(value):
+        return _validate_pagesize(value)
 
-    def validate_provider(self, input_providers):
+    @staticmethod
+    def validate_provider(input_providers):
         allowed_providers = list(get_providers('image').keys())
 
         for input_provider in input_providers.split(','):

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -190,6 +190,10 @@ class BrowseImages(APIView):
     Museum of Art.. See `/statistics/image` for a list of valid
     collections. The `provider_identifier` field should be used to select
     the provider.
+
+    As with the `/image/search` endpoint, this is not intended to be used to
+    bulk download our entire collection of images; only the first ~10,000 images
+    in each collection are accessible.
     """
 
     @swagger_auto_schema(operation_id='image_browse',

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -2,6 +2,7 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework import serializers
 from drf_yasg.utils import swagger_auto_schema
 from cccatalog.api.models import Image, ContentProvider
 from cccatalog.api.utils.validate_images import validate_images
@@ -232,6 +233,14 @@ class BrowseImages(APIView):
                 status=400,
                 data={
                     VALIDATION_ERROR: DEEP_PAGINATION_ERROR
+                }
+            )
+        except serializers.ValidationError:
+            return Response(
+                status=400,
+                data={
+                    VALIDATION_ERROR: 'Provider \'{}\' does not exist.'
+                    .format(provider)
                 }
             )
         filter_dead = params.data[FILTER_DEAD]

--- a/cccatalog-api/cccatalog/urls.py
+++ b/cccatalog-api/cccatalog/urls.py
@@ -16,10 +16,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, re_path
 from django.conf.urls import include
-from cccatalog.api.views.image_views import SearchImages, ImageDetail, Watermark
+from cccatalog.api.views.image_views import SearchImages, ImageDetail,\
+    Watermark, BrowseImages
 from cccatalog.api.views.site_views import HealthCheck, ImageStats, Register, \
     CheckRates
-from cccatalog.api.views.list_views import CreateList, ListDetail
 from cccatalog.api.views.link_views import CreateShortenedLink, \
     ResolveShortenedLink
 from cccatalog.settings import API_VERSION, WATERMARK_ENABLED
@@ -80,6 +80,7 @@ urlpatterns = [
     # path('list', CreateList.as_view()),
     # path('list/<str:slug>', ListDetail.as_view(), name='list-detail'),
     re_path('image/search', SearchImages.as_view()),
+    path('image/browse/<str:provider>', BrowseImages.as_view()),
     path('image/<str:identifier>', ImageDetail.as_view(), name='image-detail'),
     path('statistics/image', ImageStats.as_view(), name='about-image'),
     path('link', CreateShortenedLink.as_view(), name='make-link'),

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -300,3 +300,11 @@ def test_attribution():
     print(all_data_present.attribution)
     assert title in all_data_present.attribution
     assert creator in all_data_present.attribution
+
+
+def test_browse_by_provider():
+    response = requests.get(API_URL + '/image/browse/behance',
+                            verify=False)
+    assert response.status_code == 200
+    parsed = json.loads(response.text)
+    assert parsed['result_count'] > 0


### PR DESCRIPTION
Fixes #205

Allow searching by provider, without search terms, using the `/image/provider/<provider_identifier>` endpoint. This does not allow comprehensive downloading of the largest collections; only the first ~10,000 results can be accessed through this endpoint. As with our `/image/search` endpoint, this is not intended for bulk download.