### PR TITLE
Increase image validation timeout

### DIFF
--- a/cccatalog-api/cccatalog/api/utils/validate_images.py
+++ b/cccatalog-api/cccatalog/api/utils/validate_images.py
@@ -32,7 +32,7 @@ def validate_images(results, image_urls):
         if cached_statuses[idx] is None:
             to_verify[url] = idx
     reqs = (
-        grequests.head(u, allow_redirects=False, timeout=0.2, verify=False)
+        grequests.head(u, allow_redirects=False, timeout=2, verify=False)
         for u in to_verify.keys()
     )
     verified = grequests.map(reqs, exception_handler=_validation_failure)


### PR DESCRIPTION
Fixes #280.

To detect broken links, the server will send an HTTP HEAD request to each URL in the search results, and then cache them for some long period of time. Each request has a timeout of 200ms. This caused problems for image servers geographically distant from our API servers. Museums Victoria, for instance, is hosted in Australia, and it takes nearly 1.5 seconds to receive a response from them, which caused the server to think all of their links were dead. By increasing the timeout to 2 seconds, we can ensure that this edge case doesn't occur.

Because validation results are cached, there shouldn't be a big impact on API performance in the long term.