### PR TITLE
Use 'most_fields' instead of 'best_fields' 

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -93,6 +93,7 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
             'query_string',
             query=search_params.data['q'],
             fields=['tags.name', 'title'],
+            type='most_fields'
         )
     else:
         if 'creator' in search_params.data:


### PR DESCRIPTION
Relates to #303. 

Instead of using the score of the best matching field to rank results, prefer results with matches in multiple fields. It's not a panacea for search relevance, but initial testing in `ccsearch-dev` indicates that there is some improvement with our most egregious examples of low quality search results (flamingos, DNA).

See the `type` setting in the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html) for more information.