### PR TITLE
Related images endpoint

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -144,15 +144,16 @@ def related_images(uuid, index):
     s = Search(index=index)
     s = s.query(
         'more_like_this',
-        fields=['tags.name', 'title', 'creator', 'provider'],
+        fields=['tags.name', 'title', 'creator'],
         like={
             '_index': index,
             '_id': _id
         },
         min_term_freq=1,
-        max_query_terms=20
+        max_query_terms=50
     )
     response = s.execute()
+
     return response
 
 

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -129,6 +129,33 @@ def _validate_provider(input_provider):
     return input_provider.lower()
 
 
+def related_images(uuid, index):
+    """
+    Given a UUID, find related search results.
+    """
+    # Convert UUID to sequential ID.
+    item = Search(index=index)
+    item = item.query(
+        'match',
+        identifier=uuid
+    )
+    _id = item.execute().hits[0].id
+
+    s = Search(index=index)
+    s = s.query(
+        'more_like_this',
+        fields=['tags.name', 'title', 'creator', 'provider'],
+        like={
+            '_index': index,
+            '_id': _id
+        },
+        min_term_freq=1,
+        max_query_terms=20
+    )
+    response = s.execute()
+    return response
+
+
 def browse_by_provider(
         provider, index, page_size, ip, page=1, lt=None, li=None):
     """

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -268,7 +268,6 @@ class ImageSerializer(serializers.Serializer):
     )
     creator = serializers.CharField(required=False, allow_blank=True)
     creator_url = serializers.URLField(required=False)
-    legacy_tags = serializers.ListField(required=False)
     tags = TagSerializer(
         required=False,
         many=True,
@@ -286,6 +285,11 @@ class ImageSerializer(serializers.Serializer):
         required=True,
         help_text="A direct link to the detail view of an image."
     )
+
+
+class RelatedImagesResultsSerializer(serializers.Serializer):
+    result_count = serializers.IntegerField(),
+    results = ImageSerializer(many=True)
 
 
 class ImageSearchResultsSerializer(serializers.Serializer):

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -11,7 +11,7 @@ from rest_framework.reverse import reverse
 from cccatalog.api.serializers.search_serializers import\
     ImageSearchResultsSerializer, ImageSerializer,\
     ValidationErrorSerializer, ImageSearchQueryStringSerializer, \
-    BrowseImageQueryStringSerializer
+    BrowseImageQueryStringSerializer, RelatedImagesResultsSerializer
 from cccatalog.api.serializers.image_serializers import ImageDetailSerializer,\
     WatermarkQueryStringSerializer
 from cccatalog.settings import THUMBNAIL_PROXY_URL, PROXY_THUMBS, PROXY_ALL
@@ -255,6 +255,25 @@ class BrowseImages(APIView):
             RESULTS: serialized_results
         }
         serialized_response = ImageSearchResultsSerializer(data=response_data)
+        return Response(status=200, data=serialized_response.initial_data)
+
+
+class RelatedImage(APIView):
+    """
+    Given a UUID, return images related to the result.
+    """
+    def get(self, request, identifier, format=None):
+        related = search_controller.related_images(
+            uuid=identifier,
+            index='image'
+        )
+        filtered = _post_process_results(related, request, True)
+        serialized_related = ImageSerializer(filtered, many=True).data
+        response_data = {
+            'result_count': related.hits.total,
+            RESULTS: serialized_related
+        }
+        serialized_response = RelatedImagesResultsSerializer(data=response_data)
         return Response(status=200, data=serialized_response.initial_data)
 
 

--- a/cccatalog-api/cccatalog/urls.py
+++ b/cccatalog-api/cccatalog/urls.py
@@ -17,7 +17,7 @@ from django.contrib import admin
 from django.urls import path, re_path
 from django.conf.urls import include
 from cccatalog.api.views.image_views import SearchImages, ImageDetail,\
-    Watermark, BrowseImages
+    Watermark, BrowseImages, RelatedImage
 from cccatalog.api.views.site_views import HealthCheck, ImageStats, Register, \
     CheckRates
 from cccatalog.api.views.link_views import CreateShortenedLink, \
@@ -82,6 +82,11 @@ urlpatterns = [
     re_path('image/search', SearchImages.as_view()),
     path('image/browse/<str:provider>', BrowseImages.as_view()),
     path('image/<str:identifier>', ImageDetail.as_view(), name='image-detail'),
+    path(
+        'image/related/<str:identifier>',
+        RelatedImage.as_view(),
+        name='related-images'
+    ),
     path('statistics/image', ImageStats.as_view(), name='about-image'),
     path('link', CreateShortenedLink.as_view(), name='make-link'),
     path('link/<str:path>', ResolveShortenedLink.as_view(), name='resolve'),


### PR DESCRIPTION
Fixes #286.

Given a UUID, find images similar to the image. Similar images are ranked by the amount of overlap between `tags`, `title`, and `creator`. Likely candidates for similar images include other images from the same artist or user which include similar tags or titles (e.g. the related images for UserFoo's picture of a fountain in Rome likely include other images from that same trip to Rome).

This feature is in api-dev for testing; see `api-dev.creativecommons.engineering/image/related/<uuid>`