### PR TITLE
Test each provider for TLS support during ingestion

### DIFF
--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -3,7 +3,7 @@ import psycopg2
 import datetime
 import logging as log
 
-from ingestion_server.cleanup import clean_data
+from ingestion_server.cleanup import clean_image_data
 from ingestion_server.indexer import database_connect
 from psycopg2.extras import DictCursor
 
@@ -261,7 +261,7 @@ def reload_upstream(table, progress=None, finish_time=None):
         downstream_cur.execute(copy_data)
     downstream_db.commit()
     downstream_db.close()
-    clean_data(table)
+    clean_image_data(table)
     log.info('Cleaning step finished.')
     downstream_db = database_connect()
     with downstream_db.cursor() as downstream_cur:


### PR DESCRIPTION
Related to #274.

Since URLs from the CC Catalog are not guaranteed to specify a protocol, we have to test each URL individually for TLS support. This is necessary because we embed thumbnails from the content provider, and we can't display non-TLS images without compromising the TLS security of our site, which isn't acceptable in this day and age.

Once we start hosting our own thumbnails, we should remove this check from the ingestion process.