### PR TITLE
Exempt request from rate limiting if it originates from our internal network

### DIFF
--- a/analytics/README.md
+++ b/analytics/README.md
@@ -15,7 +15,7 @@ data (along with session UUIDs) will be promptly deleted.
 
 ## Running the server
 
-Analytics server is automatically started by `docker-compose` in the parent
+The analytics server is automatically started by `docker-compose` in the parent
 directory. Before analytics endpoints can be called, the database needs to
 be set up with `../load_sample_data.sh`.
 

--- a/cccatalog-api/cccatalog/api/utils/throttle.py
+++ b/cccatalog-api/cccatalog/api/utils/throttle.py
@@ -19,7 +19,7 @@ class AnonRateThrottle(SimpleRateThrottle):
     scope = 'anon'
 
     def get_cache_key(self, request, view):
-        if _from_internal_network:
+        if _from_internal_network(self.get_ident(request)):
             return None
         # Do not throttle requests with a valid access token.
         if request.auth:
@@ -63,7 +63,7 @@ class OAuth2IdThrottleRate(SimpleRateThrottle):
     applies_to_rate_limit_model = 'standard'
 
     def get_cache_key(self, request, view):
-        if _from_internal_network:
+        if _from_internal_network(self.get_ident(request)):
             return None
         # Find the client ID associated with the access token.
         client_id, rate_limit_model = get_token_info(str(request.auth))

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -35,6 +35,12 @@ ALLOWED_HOSTS = ['localhost', '127.0.0.1', os.environ.get('LOAD_BALANCER_URL'),
                  "api.creativecommons.engineering",
                  gethostname(), gethostbyname(gethostname())]
 
+# Rate limits are not applied to requests that originate from whitelisted
+# internal networks. This is matched against the start of request IPs (e.g.
+# for the setting '172.30', a request from 172.30.0.3 will be accepted while
+# 172.25.0.1 will be rejected)
+TRUSTED_NETWORK = os.environ.get('TRUSTED_NETWORK', '172.30')
+
 # Domains that shortened links may point to
 SHORT_URL_WHITELIST = {
     'api-dev.creativecommons.engineering',


### PR DESCRIPTION
Don't throttle requests from our own network. This allows us to run our static site renderer without throttling it needlessly.

The nginx proxy in front of the SSR will need to be configured to throttle requests to prevent abuse, otherwise it would essentially allow users to crawl the catalog through the frontend.