### PR TITLE
Implement the trusted IP whitelist in Redis

### DIFF
--- a/cccatalog-api/cccatalog/api/utils/throttle.py
+++ b/cccatalog-api/cccatalog/api/utils/throttle.py
@@ -1,13 +1,14 @@
 from rest_framework.throttling import SimpleRateThrottle
 import logging
-from cccatalog.settings import TRUSTED_NETWORK
 from cccatalog.api.utils.oauth2_helper import get_token_info
+from django_redis import get_redis_connection
 
 log = logging.getLogger(__name__)
 
 
 def _from_internal_network(ip):
-    return ip.startswith(TRUSTED_NETWORK)
+    redis = get_redis_connection('default')
+    return redis.sismember('ip-whitelist', ip)
 
 
 class AnonRateThrottle(SimpleRateThrottle):

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -35,12 +35,6 @@ ALLOWED_HOSTS = ['localhost', '127.0.0.1', os.environ.get('LOAD_BALANCER_URL'),
                  "api.creativecommons.engineering",
                  gethostname(), gethostbyname(gethostname())]
 
-# Rate limits are not applied to requests that originate from whitelisted
-# internal networks. This is matched against the start of request IPs (e.g.
-# for the setting '172.30', a request from 172.30.0.3 will be accepted while
-# 172.25.0.1 will be rejected)
-TRUSTED_NETWORK = os.environ.get('TRUSTED_NETWORK', '172.30')
-
 # Domains that shortened links may point to
 SHORT_URL_WHITELIST = {
     'api-dev.creativecommons.engineering',


### PR DESCRIPTION
Internal clients can register their IP address in Redis to prevent being throttled.

Example self-registration:
```
redis-cli -h ${redis_url} sadd ip-whitelist $IPV4_ADDRESS
```

The 'trusted network' configuration idea was flawed; requests to the API are resolved by their public IPs, even when they're coming from our public network. To make the requests from the private network would mean setting up a separate internal load balancer, a private DNS zone, and some more frontend logic to make use of it. Rather than go that route, let's just have the front end servers self-add themselves to the Redis whitelist.