### PR TITLE
Ignore invalid use of quotation marks

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -42,6 +42,10 @@ def _filter_licenses(s: Search, licenses):
 
 
 def _quote_escape(query_string):
+    """
+    If there are any unmatched quotes in the query supplied by the user, ignore
+    them.
+    """
     num_quotes = query_string.count('"')
     if num_quotes % 2 == 1:
         return query_string.replace('"', '\\"')

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -41,6 +41,14 @@ def _filter_licenses(s: Search, licenses):
     return s
 
 
+def _quote_escape(query_string):
+    num_quotes = query_string.count('"')
+    if num_quotes % 2 == 1:
+        return query_string.replace('"', '\\"')
+    else:
+        return query_string
+
+
 def search(search_params, index, page_size, ip, page=1) -> Response:
     """
     Given a set of keywords and an optional set of filters, perform a ranked
@@ -90,25 +98,26 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
     # individual field-level queries specified.
     search_fields = ['tags.name', 'title', 'description']
     if 'q' in search_params.data:
+        query = _quote_escape(search_params.data['q'])
         s = s.query(
             'query_string',
-            query=search_params.data['q'],
+            query=query,
             fields=search_fields,
             type='most_fields'
         )
     else:
         if 'creator' in search_params.data:
-            creator = search_params.data['creator']
+            creator = _quote_escape(search_params.data['creator'])
             s = s.query(
                 'query_string', query=creator, default_field='creator'
             )
         if 'title' in search_params.data:
-            title = search_params.data['title']
+            title = _quote_escape(search_params.data['title'])
             s = s.query(
                 'query_string', query=title, default_field='title'
             )
         if 'tags' in search_params.data:
-            tags = search_params.data['tags']
+            tags = _quote_escape(search_params.data['tags'])
             s = s.query(
                 'query_string',
                 default_field='tags.name',

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -35,6 +35,13 @@ def search_fixture():
     parsed = json.loads(response.text)
     return parsed
 
+def test_search_quotes():
+    """
+    We want to return a response even if the user messes up quote matching.
+    """
+    response = requests.get(API_URL + '/image/search?q="test', verify=False)
+    assert response.status_code == 200
+
 
 def test_search(search_fixture):
     assert search_fixture['result_count'] > 0


### PR DESCRIPTION
Related to https://github.com/creativecommons/cccatalog-frontend/issues/474

Elasticsearch `query_string` queries uses double quotes to indicate exact matches. A single quote on its own is an unfinished exact match query, which is an error.

In order to make it a little harder for users to shoot themselves in the foot, we can escape quotation marks if any of them are unmatched.