### PR TITLE
Provider relevance weighting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
   - bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w ''%{http_code}'' http://localhost:8000/healthcheck)" != "200" ]]; do sleep 10 && docker logs cccatalog-api_web_1; done'
   - ./load_sample_data.sh
   - bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w ''%{http_code}'' http://localhost:8000/image/search?q=test)" != "200" ]]; do sleep 5; done'
+  - bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w ''%{http_code}'' http://localhost:9200/image)" != "200" ]]; do sleep 5; done'
 script:
   - pycodestyle cccatalog-api/cccatalog --exclude='cccatalog-api/cccatalog/api/migrations' --max-line-length=80 --ignore=E402 
   - pycodestyle ingestion_server/*.py --max-line-length=80 --ignore=E402

--- a/analytics/docs/swagger.yaml
+++ b/analytics/docs/swagger.yaml
@@ -131,6 +131,7 @@ definitions:
         description: "A unique identifier labeling an anonymous user's session."
       rating:
         type: "integer"
+        description: "An integer ranging from 1-5 inclusive"
         example: 5
       
   CreateResultClickEvent:

--- a/cccatalog-api/Pipfile
+++ b/cccatalog-api/Pipfile
@@ -32,7 +32,7 @@ django-redis = "*"
 pytest-django = ">=3.5"
 djangorestframework = "*"
 drf-yasg = "*"
-elasticsearch-dsl = "*"
+elasticsearch-dsl = "==7.0.0"
 ipaddress = {version = "*",python_version = "<=2.7"}
 piexif = "*"
 python-xmp-toolkit = "*"

--- a/cccatalog-api/Pipfile.lock
+++ b/cccatalog-api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1c3eaa6a855a8177a4f817bee5e307e8a9b4ec0fefd93b204a7c04d8270b7371"
+            "sha256": "e1f15ea5cdb23c6a1ed5826e8d151bf157bf1e8d3960e42fe65c12c3a026deb6"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -94,11 +94,11 @@
         },
         "django-cors-headers": {
             "hashes": [
-                "sha256:5b80bf0f8d7fc6e2bcb4f40781d5ff3661961bbf1982e52daec77241dea3b890",
-                "sha256:ebf3e2cf25aa6993b959a8e6a87828ebb3c8fe5bc3ec4a2d6e65f3b8d9b4212c"
+                "sha256:e4b12209b3a0bc577883fe0ac0aa3adac9e82742389f8ddb6c6b41c66b1e9c4f",
+                "sha256:e69b1c909f2eddc7ef2a24f071583bc22b73b871731ea3370ac52b3318c43b3c"
             ],
             "index": "pypi",
-            "version": "==3.0.2"
+            "version": "==3.1.0"
         },
         "django-cron": {
             "hashes": [
@@ -256,6 +256,7 @@
                 "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
                 "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
             ],
+            "markers": "python_version < '3.8'",
             "version": "==0.19"
         },
         "inflection": {
@@ -444,10 +445,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d",
-                "sha256:a736fed91c12681a7b34617c8fcefe39ea04599ca72c608751c31d89579a3f77"
+                "sha256:95b1f6db806e5b1b5b443efeb58984c24945508f93a866c1719e1a507a957d7c",
+                "sha256:c3d5020755f70c82eceda3feaf556af9a341334414a8eca521a18f463bcead88"
             ],
-            "version": "==5.0.1"
+            "version": "==5.1.1"
         },
         "pytest-django": {
             "hashes": [
@@ -494,10 +495,10 @@
         },
         "redis": {
             "hashes": [
-                "sha256:0607faf60d44768e17f65e506fe390679b54be6fd6d5f0c2d28f3ebf4f0535e7",
-                "sha256:9c96c5bf11a8c47eb33cefdefd41c47cf1ff68db41c51b56b3ec7938b7c627f7"
+                "sha256:98a22fb750c9b9bb46e75e945dc3f61d0ab30d06117cbb21ff9cd1d315fedd3b",
+                "sha256:c504251769031b0dd7dd5cf786050a6050197c6de0d37778c80c08cb04ae8275"
             ],
-            "version": "==3.3.7"
+            "version": "==3.3.8"
         },
         "redlock-py": {
             "hashes": [
@@ -523,10 +524,10 @@
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:547aeab5c51c93bc750ed2a320c1559b605bde3aa569216aa75fd91d8a1c4623",
-                "sha256:c5e239b6a4f26baabb2e22b145582a7d99ae9d4ebb8902291365a61ed38faa7f"
+                "sha256:0db639b1b2742dae666c6fc009b8d1931ef15c9276ef31c0673cc6dcf766cf40",
+                "sha256:412a6f5cfdc0525dee6a27c08f5415c7fd832a7afcb7a0ed7319628aed23d408"
             ],
-            "version": "==0.16.1"
+            "version": "==0.16.5"
         },
         "ruamel.yaml.clib": {
             "hashes": [
@@ -718,11 +719,11 @@
         },
         "remote-pdb": {
             "hashes": [
-                "sha256:0a5835ae6f75244bf728616f41a57b35dab4d17f51601bd5f80413ee9b4b5732",
-                "sha256:e441ddde7e74dd17c1ce924a20e998b22e560e53c404a0f9266be7f9900c1f3f"
+                "sha256:2a1602ac1ec42e4c88da73c7221ca7f5a8559405b962eb0dbb2cdf413558b156",
+                "sha256:ad38f36f539b22be820f94062618366d5d3461115c1605b11679dba75f94ee62"
             ],
             "index": "pypi",
-            "version": "==1.3.0"
+            "version": "==2.0.0"
         },
         "six": {
             "hashes": [

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -29,6 +29,7 @@ def _paginate_search(s: Search, page_size: int, page: int):
     if start_slice + end_slice > ELASTICSEARCH_MAX_RESULT_WINDOW:
         raise ValueError("Deep pagination is not allowed.")
     s = s[start_slice:end_slice]
+    print('pagination: {},{}'.format(start_slice, end_slice))
     return s
 
 
@@ -62,7 +63,6 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
     :return: An Elasticsearch Response object.
     """
     s = Search(index=index)
-    s = _paginate_search(s, page_size, page)
     # Add requested filters.
     if 'li' in search_params.data:
         s = _filter_licenses(s, search_params.data['li'])
@@ -141,6 +141,7 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
     # Route users to the same Elasticsearch worker node to reduce
     # pagination inconsistencies and increase cache hits.
     s = s.params(preference=str(ip))
+    s = _paginate_search(s, page_size, page)
     search_response = s.execute()
     return search_response.to_dict()
 

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -29,7 +29,6 @@ def _paginate_search(s: Search, page_size: int, page: int):
     if start_slice + end_slice > ELASTICSEARCH_MAX_RESULT_WINDOW:
         raise ValueError("Deep pagination is not allowed.")
     s = s[start_slice:end_slice]
-    print('pagination: {},{}'.format(start_slice, end_slice))
     return s
 
 

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -134,7 +134,8 @@ def search(search_params, index, page_size, ip, page=1) -> Response:
     # Prioritize curated collections over social collections.
     rank_feature_query = Q(
         'rank_feature',
-        field='provider_relevance'
+        field='provider_relevance',
+        boost=100
     )
     s = Search().query(
         Q(

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -92,9 +92,8 @@ def _post_process_results(search_results, request, filter_dead):
             reverse('image-detail', [res['identifier']])
         )
         res['detail'] = url
-        if 'highlight' in res:
-            res['fields_matched'] = list(res['highlight'].keys())
-            res.fields_matched = res['meta']['highlight']
+        if 'highlight' in _res:
+            res['fields_matched'] = list(_res['highlight'].keys())
         to_validate.append(res['url'])
         if PROXY_THUMBS:
             # Proxy thumbnails from providers who don't provide SSL. We also

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -65,7 +65,7 @@ def _get_page_count(search_results, page_size):
     :param search_results: The Elasticsearch response object containing search
     results.
     """
-    natural_page_count = int(search_results.hits.total / page_size)
+    natural_page_count = int(search_results.hits.total['value'] / page_size)
     last_allowed_page = int((5000 + page_size / 2) / page_size)
     page_count = min(natural_page_count, last_allowed_page)
     return page_count

--- a/cccatalog-api/test/api_live_integration_test.py
+++ b/cccatalog-api/test/api_live_integration_test.py
@@ -48,19 +48,22 @@ def test_search_consistency():
     appear in the first few pages of a search query.
     """
     n_pages = 5
-    searches = set(
-        requests.get(API_URL + '/image/search?q=honey;page={}'.format(page),
+    pages = set(
+        requests.get(API_URL + '/image/search?q=about&page={}'.format(page),
                      verify=False)
-        for page in range(1, n_pages)
+        for page in range(1, n_pages + 1)
     )
 
     images = set()
-    for response in searches:
+    dupe_count = 0
+    for response in pages:
         parsed = json.loads(response.text)
         for result in parsed['results']:
             image_id = result['id']
-            assert image_id not in images
+            if image_id in images:
+                dupe_count += 1
             images.add(image_id)
+    assert dupe_count == 0
 
 
 def test_image_detail(search_fixture):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,6 @@ services:
     command: bash -c 'sleep 20 && supervisord -c config/supervisord.conf'
     ports: 
       - "8001:8001"
-      - "4445:4445"
     depends_on:
       - db
       - es

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,13 +31,12 @@ services:
       test: "pg_isready -U deploy -d openledger"
 
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.1.0
     ports:
       - "9200:9200"
     environment:
-      # disable XPack
-      # https://www.elastic.co/guide/en/elasticsearch/reference/5.3/docker.html#_security_note
       - xpack.security.enabled=false
+      - discovery.type=single-node
     healthcheck:
       test: ["CMD-SHELL", "curl -si -XGET 'localhost:9200/_cluster/health?pretty' | grep -qE 'yellow|green'"]
       interval: 10s
@@ -85,6 +84,7 @@ services:
     command: bash -c 'sleep 20 && supervisord -c config/supervisord.conf'
     ports: 
       - "8001:8001"
+      - "4445:4445"
     depends_on:
       - db
       - es

--- a/ingestion_server/Pipfile
+++ b/ingestion_server/Pipfile
@@ -12,7 +12,7 @@ pycodestyle = "*"
 [packages]
 aws-requests-auth = "*"
 bottle="*"
-elasticsearch-dsl = "==6.3.1"
+elasticsearch-dsl = "==7.0.0"
 falcon="*"
 gunicorn="*"
 psycopg2-binary = "*"

--- a/ingestion_server/Pipfile.lock
+++ b/ingestion_server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3951281f42bc61bf6cb11d461e01b94b1fb2c0862cdb3579ab2260c72f092b07"
+            "sha256": "e0d5cbac42227843db1da04e7c0b66c1995628c4fef7ef085bca0fbbbd64abd8"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -45,18 +45,18 @@
         },
         "elasticsearch": {
             "hashes": [
-                "sha256:1f0f633e3b500d5042424f75a505badf8c4b9962c1b4734cdfb3087fb67920be",
-                "sha256:fb5ab15ee283f104b5a7a5695c7e879cb2927e4eb5aed9c530811590b41259ad"
+                "sha256:cbc73831c63fa2824538df76fcb2c4be007b43dbd9e7788ae70ea6d24109925b",
+                "sha256:d1b176b87a7fb75dca82978c82a4023e8b21cbc98f4018cb51190fb0b8b43764"
             ],
-            "version": "==6.4.0"
+            "version": "==7.0.2"
         },
         "elasticsearch-dsl": {
             "hashes": [
-                "sha256:5f43196a3fd91b2eac90f7345e99f92c66004d85a1fd803cdecf756430827231",
-                "sha256:5f80b3b4a6e61db5d273bc57c32a80b2ddbc555afcc122c62c20440c355008be"
+                "sha256:2aedc2a4dbba9870249a57d1798ec29e44404619bded66ac920f5d6a1cbb6f22",
+                "sha256:763fb28add254f2c3a1d071cd114466d8a27f640e02a874afba7b8a04147c094"
             ],
             "index": "pypi",
-            "version": "==6.3.1"
+            "version": "==7.0.0"
         },
         "falcon": {
             "hashes": [
@@ -136,20 +136,22 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:57acc1d8533cbe51f6662a55434f0dbecfa2b9eaf115bede8f6fd00115a0c0d3",
-                "sha256:588c94b3d16b76cfed8e0be54932e5729cc185caffaa5a451e7ad2f7ed8b4043",
-                "sha256:68c8dd247f29f9a0d09375c9c6b8fdc64b60810ebf07ba4cdd64ceee3a58c7b7",
-                "sha256:70d9818f1c9cd5c48bb87804f2efc8692f1023dac7f1a1a5c61d454043c1d265",
-                "sha256:86a93cccd50f8c125286e637328ff4eef108400dd7089b46a7be3445eecfa391",
-                "sha256:a0f329125a926876f647c9fa0ef32801587a12328b4a3c741270464e3e4fa778",
-                "sha256:a3c252ab0fa1bb0d5a3f6449a4826732f3eb6c0270925548cac342bc9b22c225",
-                "sha256:b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab7f3ac2770955",
-                "sha256:cd0618c5ba5bda5f4039b9398bb7fb6a317bb8298218c3de25c47c4740e4b95e",
-                "sha256:ceacb9e5f8474dcf45b940578591c7f3d960e82f926c707788a570b51ba59190",
-                "sha256:fe6a88094b64132c4bb3b631412e90032e8cfe9745a58370462240b8cb7553cd"
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
             ],
             "index": "pypi",
-            "version": "==5.1.1"
+            "version": "==5.1.2"
         },
         "requests": {
             "hashes": [
@@ -198,11 +200,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:54c5a8aa1eadd269ac210b96923688ccf01ebb2d0f21c18c3c717909583579a8",
-                "sha256:e840810029224b56cd0d9e7719dc3b39cf84d577f8ac686547c8ba7a06eeab26"
+                "sha256:1d3a1692921e932751bc1a1f7bb96dc38671eeefdc66ed33ee4cbc57e92a410e",
+                "sha256:537cd0176ff6abd06ef3e23f2d0c4c2c8a4d9277b7451544c6cbf56d1c79a83d"
             ],
             "index": "pypi",
-            "version": "==7.5.0"
+            "version": "==7.7.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -213,17 +215,17 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:49ccb782651bb6f7009810d17a3316f8867dde31654c750506970742e18b553d",
-                "sha256:79d0f6595f3846dffcbe667cc6dc821b96e5baa8add125176c31a3917eb19d58"
+                "sha256:786b6c3d80e2f06fd77162a07fed81b8baa22dde5d62896a790a331d6ac21a27",
+                "sha256:ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e"
             ],
-            "version": "==0.14.0"
+            "version": "==0.15.1"
         },
         "parso": {
             "hashes": [
-                "sha256:5052bb33be034cba784193e74b1cde6ebf29ae8b8c1e4ad94df0c4209bfc4826",
-                "sha256:db5881df1643bf3e66c097bfd8935cf03eae73f4cb61ae4433c9ea4fb6613446"
+                "sha256:63854233e1fadb5da97f2744b6b24346d2750b85965e7e399bec1620232797dc",
+                "sha256:666b0ee4a7a1220f65d367617f2cd3ffddff3e205f3f16a0284df30e774c2a9c"
             ],
-            "version": "==0.5.0"
+            "version": "==0.5.1"
         },
         "pexpect": {
             "hashes": [
@@ -281,11 +283,11 @@
         },
         "remote-pdb": {
             "hashes": [
-                "sha256:0a5835ae6f75244bf728616f41a57b35dab4d17f51601bd5f80413ee9b4b5732",
-                "sha256:e441ddde7e74dd17c1ce924a20e998b22e560e53c404a0f9266be7f9900c1f3f"
+                "sha256:2a1602ac1ec42e4c88da73c7221ca7f5a8559405b962eb0dbb2cdf413558b156",
+                "sha256:ad38f36f539b22be820f94062618366d5d3461115c1605b11679dba75f94ee62"
             ],
             "index": "pypi",
-            "version": "==1.3.0"
+            "version": "==2.0.0"
         },
         "six": {
             "hashes": [

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -1,5 +1,5 @@
-from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType
-import json
+from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType,\
+    Double
 import logging
 
 """
@@ -65,6 +65,8 @@ class Image(SyncableDocType):
     meta_data = Nested()
     view_count = Integer()
     description = Text(analyzer="english")
+    # A rank_feature field
+    relevance_boost = Double()
 
     class Index:
         name = 'image'

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -1,5 +1,6 @@
 from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType,\
     Double
+from ingestion_server.rank import get_provider_relevance
 import logging
 
 """
@@ -65,8 +66,8 @@ class Image(SyncableDocType):
     meta_data = Nested()
     view_count = Integer()
     description = Text(analyzer="english")
-    # A rank_feature field
-    relevance_boost = Double()
+    # Priority of the content provider. We prioritize curated collections.
+    provider_relevance = Double()
 
     class Index:
         name = 'image'
@@ -104,7 +105,8 @@ class Image(SyncableDocType):
             foreign_landing_url=row[schema['foreign_landing_url']],
             meta_data=None,
             view_count=row[schema['view_count']],
-            description=_parse_description(row[schema['meta_data']])
+            description=_parse_description(row[schema['meta_data']]),
+            provider_relevance=get_provider_relevance(row[schema['provider']])
         )
 
 

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -1,7 +1,6 @@
 from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType,\
-    Double
+    Double, Field
 from ingestion_server.rank import get_provider_relevance
-import logging
 
 """
 Provides an ORM-like experience for accessing data in Elasticsearch.
@@ -9,6 +8,10 @@ Provides an ORM-like experience for accessing data in Elasticsearch.
 Note the actual schema for Elasticsearch is defined in es_mapping.py; any
 low-level changes to the index must be represented there as well.
 """
+
+
+class RankFeature(Field):
+    name = 'rank_feature'
 
 
 class SyncableDocType(DocType):
@@ -66,8 +69,9 @@ class Image(SyncableDocType):
     meta_data = Nested()
     view_count = Integer()
     description = Text(analyzer="english")
-    # Priority of the content provider. We prioritize curated collections.
-    provider_relevance = Double()
+    # Priority of the content provider for this record. We prioritize curated
+    # collections.
+    provider_relevance = RankFeature
 
     class Index:
         name = 'image'

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -71,7 +71,7 @@ class Image(SyncableDocType):
     description = Text(analyzer="english")
     # Priority of the content provider for this record. We prioritize curated
     # collections.
-    provider_relevance = RankFeature
+    provider_relevance = RankFeature()
 
     class Index:
         name = 'image'

--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -126,6 +126,9 @@ def create_mapping(table_name):
                       },
                       "type": "text",
                       "analyzer": "english"
+                   },
+                   "relevance_boost": {
+                      "type": "rank_feature"
                    }
                 }
            }

--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -127,7 +127,7 @@ def create_mapping(table_name):
                       "type": "text",
                       "analyzer": "english"
                    },
-                   "relevance_boost": {
+                   "provider_relevance": {
                       "type": "rank_feature"
                    }
                 }

--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -8,128 +8,126 @@ def create_mapping(table_name):
     mapping = {
         'image': {
            "mappings": {
-               "doc": {
-                   "properties": {
-                      "license_version": {
-                         "type": "text",
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
+                "properties": {
+                   "license_version": {
+                      "type": "text",
+                      "fields": {
+                         "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
                          }
-                      },
-                      "view_count": {
-                         "type": "long"
-                      },
-                      "provider": {
-                         "type": "text",
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         }
-                      },
-                      "source": {
-                         "fields": {
-                            "keyword": {
-                               "ignore_above": 256,
-                               "type": "keyword"
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "license": {
-                         "fields": {
-                            "keyword": {
-                               "ignore_above": 256,
-                               "type": "keyword"
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "url": {
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "tags": {
-                         "properties": {
-                            "accuracy": {
-                               "type": "float"
-                            },
-                            "name": {
-                               "type": "text",
-                               "fields": {
-                                  "keyword": {
-                                     "type": "keyword",
-                                     "ignore_above": 256
-                                  }
-                               },
-                               "analyzer": "english"
-                            }
-                         }
-                      },
-                      "foreign_landing_url": {
-                         "fields": {
-                            "keyword": {
-                               "ignore_above": 256,
-                               "type": "keyword"
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "id": {
-                         "type": "long"
-                      },
-                      "identifier": {
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "title": {
-                         "type": "text",
-                         "similarity": "boolean",
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         },
-                         "analyzer": "english"
-                      },
-                      "creator": {
-                         "type": "text",
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         }
-                      },
-                      "created_on": {
-                         "type": "date"
-                      },
-                      "description": {
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword"
-                            }
-                         },
-                         "type": "text",
-                         "analyzer": "english"
                       }
+                   },
+                   "view_count": {
+                      "type": "long"
+                   },
+                   "provider": {
+                      "type": "text",
+                      "fields": {
+                         "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                         }
+                      }
+                   },
+                   "source": {
+                      "fields": {
+                         "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                         }
+                      },
+                      "type": "text"
+                   },
+                   "license": {
+                      "fields": {
+                         "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                         }
+                      },
+                      "type": "text"
+                   },
+                   "url": {
+                      "fields": {
+                         "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                         }
+                      },
+                      "type": "text"
+                   },
+                   "tags": {
+                      "properties": {
+                         "accuracy": {
+                            "type": "float"
+                         },
+                         "name": {
+                            "type": "text",
+                            "fields": {
+                               "keyword": {
+                                  "type": "keyword",
+                                  "ignore_above": 256
+                               }
+                            },
+                            "analyzer": "english"
+                         }
+                      }
+                   },
+                   "foreign_landing_url": {
+                      "fields": {
+                         "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                         }
+                      },
+                      "type": "text"
+                   },
+                   "id": {
+                      "type": "long"
+                   },
+                   "identifier": {
+                      "fields": {
+                         "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                         }
+                      },
+                      "type": "text"
+                   },
+                   "title": {
+                      "type": "text",
+                      "similarity": "boolean",
+                      "fields": {
+                         "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                         }
+                      },
+                      "analyzer": "english"
+                   },
+                   "creator": {
+                      "type": "text",
+                      "fields": {
+                         "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                         }
+                      }
+                   },
+                   "created_on": {
+                      "type": "date"
+                   },
+                   "description": {
+                      "fields": {
+                         "keyword": {
+                            "type": "keyword"
+                         }
+                      },
+                      "type": "text",
+                      "analyzer": "english"
                    }
-               }
+                }
            }
         }
     }

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -303,7 +303,7 @@ class TableIndexer:
             }
         }
         last_doc_es = self.es.search(index=new_index, body=query)
-        return True if last_doc_es['hits']['total'] > 0 else False
+        return True if last_doc_es['hits']['total']['value'] > 0 else False
 
     def _go_live(self, write_index, live_alias):
         """

--- a/ingestion_server/ingestion_server/rank.py
+++ b/ingestion_server/ingestion_server/rank.py
@@ -1,0 +1,30 @@
+import enum
+"""
+To improve the relevance of search results, we prefer curated collections (such 
+as those from the MET museum, NYPL, Rjiksmuseum, ...) over social media sites,
+such as Flickr and Behance.
+
+If there are matches from a curated collection, they will appear in the results 
+first, even if there is a stronger keyword match in a social collection.
+"""
+DEPRIORITIZED = 'deprioritized'
+DEFAULT = 'default'
+
+
+relevance_categories = {
+    DEFAULT: 10,
+    DEPRIORITIZED: 1
+}
+
+provider_relevance_category = {
+    'behance': DEPRIORITIZED,
+    'flickr': DEPRIORITIZED
+}
+
+
+def get_provider_relevance(provider):
+    if provider in provider_relevance_category:
+        relevance_category = provider_relevance_category[provider]
+        return relevance_categories[relevance_category]
+    else:
+        return relevance_categories[DEFAULT]

--- a/ingestion_server/ingestion_server/rank.py
+++ b/ingestion_server/ingestion_server/rank.py
@@ -1,4 +1,3 @@
-import enum
 """
 To improve the relevance of search results, we prefer curated collections (such 
 as those from the MET museum, NYPL, Rjiksmuseum, ...) over social media sites,
@@ -18,7 +17,10 @@ relevance_categories = {
 
 provider_relevance_category = {
     'behance': DEPRIORITIZED,
-    'flickr': DEPRIORITIZED
+    'flickr': DEPRIORITIZED,
+    'svgsilh': DEPRIORITIZED,
+    'deviantart': DEPRIORITIZED,
+    'thingiverse': DEPRIORITIZED
 }
 
 

--- a/ingestion_server/test/integration_tests.py
+++ b/ingestion_server/test/integration_tests.py
@@ -265,6 +265,7 @@ class TestIngestion(unittest.TestCase):
         msg = "id {} should not show up in search results.".format(id_to_check)
         self.assertEqual(0, num_hits, msg)
 
+
 if __name__ == '__main__':
     log_level = logging.INFO if ENABLE_DETAILED_LOGS else logging.CRITICAL
     logging.basicConfig(level=log_level)

--- a/ingestion_server/test/integration_tests.py
+++ b/ingestion_server/test/integration_tests.py
@@ -237,7 +237,7 @@ class TestIngestion(unittest.TestCase):
         self.assertEqual(1, len(resp_json), msg)
     
     def test05_removed_from_source_not_indexed(self):
-        id_to_check = 10494466  #Index for which we changed manually False to True
+        id_to_check = 10494466  # A record that should not be indexed.
         es = Elasticsearch(
             host='localhost',
             port=60001,

--- a/ingestion_server/test/integration_tests.py
+++ b/ingestion_server/test/integration_tests.py
@@ -228,7 +228,7 @@ class TestIngestion(unittest.TestCase):
             body=es_query
         )
         msg = 'There should be 1000 documents in Elasticsearch after ingestion.'
-        self.assertEquals(search_response['hits']['total'], 1000, msg)
+        self.assertEquals(search_response['hits']['total']['value'], 1000, msg)
 
     def test04_last_task_in_status_list(self):
         resp = requests.get('http://localhost:60002/task')
@@ -261,7 +261,7 @@ class TestIngestion(unittest.TestCase):
             body=es_query
         )
 
-        num_hits = search_response['hits']['total']
+        num_hits = search_response['hits']['total']['value']
         msg = "id {} should not show up in search results.".format(id_to_check)
         self.assertEqual(0, num_hits, msg)
 


### PR DESCRIPTION
Related to #312 

Deprioritize social media providers of CC Content. They'll still show up in the search results if there's a strong match, but curated collections will get first priority.

This also lays the foundation for us to boost relevance with other factors, such as view count or "likes" on the original platform. The PR will be deployed to development for indexing testing today.