### PR TITLE
Expose height and width of images when available

### DIFF
--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -60,7 +60,8 @@ class ImageDetailSerializer(ModelSerializer, ImageSerializer):
         fields = ('title', 'id', 'creator', 'creator_url', 'tags',
                   'url', 'thumbnail', 'provider', 'source', 'license',
                   'license_version', 'foreign_landing_url', 'meta_data',
-                  'view_count', 'provider_url', 'license_url', 'attribution')
+                  'view_count', 'provider_url', 'license_url', 'attribution',
+                  'height', 'width')
 
 
 class WatermarkQueryStringSerializer(serializers.Serializer):

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -289,6 +289,14 @@ class ImageSerializer(serializers.Serializer):
         required=False,
         help_text="List the fields that matched the query for this result."
     )
+    height = serializers.IntegerField(
+        required=False,
+        help_text="The height of the image in pixels. Not always available."
+    )
+    width = serializers.IntegerField(
+        required=False,
+        help_text="The width of the image in pixels. Not always available."
+    )
 
 
 class RelatedImagesResultsSerializer(serializers.Serializer):

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -65,6 +65,8 @@ class Image(SyncableDocType):
     meta_data = Nested()
     view_count = Integer()
     description = Text(analyzer="english")
+    height = Integer()
+    width = Integer()
 
     class Index:
         name = 'image'
@@ -102,7 +104,9 @@ class Image(SyncableDocType):
             foreign_landing_url=row[schema['foreign_landing_url']],
             meta_data=None,
             view_count=row[schema['view_count']],
-            description=_parse_description(row[schema['meta_data']])
+            description=_parse_description(row[schema['meta_data']]),
+            height=row[schema['height']],
+            width=row[schema['width']]
         )
 
 

--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -127,6 +127,12 @@ def create_mapping(table_name):
                          },
                          "type": "text",
                          "analyzer": "english"
+                      },
+                      "height": {
+                         "type": "integer"
+                      },
+                      "width": {
+                         "type": "integer"
                       }
                    }
                }


### PR DESCRIPTION
Fixes #306 

Add "height" and "width" parameters to search results and detail views. Since not all integrated upstream APIs expose this, not all images will have this information available.