### PR TITLE
Add support for filtering by multiple extensions

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -205,9 +205,12 @@ def search(search_params, index, page_size, ip, request,
             provider_filters.append(Q('term', provider=provider))
         s = s.filter('bool', should=provider_filters, minimum_should_match=1)
     if 'extension' in search_params.data:
-        extension = search_params.data['extension']
-        extension_filter = Q('term', extension=extension)
-        s = s.filter('bool', should=extension_filter, minimum_should_match=1)
+        extensions = search_params.data['extension'].split(',')
+        extension_filters = []
+        for extension in extensions:
+            extension_filter = Q('term', extension=extension)
+            extension_filters.append(extension_filter)
+        s = s.filter('bool', should=extension_filters, minimum_should_match=1)
 
     # It is sometimes desirable to hide content providers from the catalog
     # without scrubbing them from the database or reindexing.

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -169,7 +169,7 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
     )
     extension = serializers.CharField(
         label="extension",
-        help_text="Filter by file extension, such as JPG or GIF.",
+        help_text="A comma separated list of desired file extensions.",
         required=False
     )
     qa = serializers.BooleanField(


### PR DESCRIPTION
Fixes #338 

Allow filtering searches by multiple file extensions simultaneously instead of just one.