### PR TITLE
Popularity boosting (with caveats)

### DIFF
--- a/cccatalog-api/Pipfile
+++ b/cccatalog-api/Pipfile
@@ -32,7 +32,7 @@ django-redis = "*"
 pytest-django = ">=3.5"
 djangorestframework = "*"
 drf-yasg = "*"
-elasticsearch-dsl = "*"
+elasticsearch-dsl = "==7.0.0"
 ipaddress = {version = "*",python_version = "<=2.7"}
 piexif = "*"
 python-xmp-toolkit = "*"

--- a/cccatalog-api/Pipfile.lock
+++ b/cccatalog-api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9f021f8f25346e777f34783bfa26fe9ae4d2b64d7d7a28cb5621df2856eebbf1"
+            "sha256": "7676cdba05e0f95ee15e9bc7eff3f301c25c57dcbf2c40f771e01e0a9d8736fc"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -65,11 +65,11 @@
         },
         "deepdiff": {
             "hashes": [
-                "sha256:1123762580af0904621136d117c8397392a244d3ff0fa0a50de57a7939582476",
-                "sha256:6ab13e0cbb627dadc312deaca9bef38de88a737a9bbdbfbe6e3857748219c127"
+                "sha256:51a1228346c91c8dbb586caefb9df6dddfed3a0abff834e72f547a5e405e0fc6",
+                "sha256:62ca21020e9c01383b5c45b9d89f418bdb78b4bb53f1d2374cd09db549e6959a"
             ],
             "index": "pypi",
-            "version": "==4.0.7"
+            "version": "==4.0.8"
         },
         "defusedxml": {
             "hashes": [
@@ -102,11 +102,11 @@
         },
         "django-cors-headers": {
             "hashes": [
-                "sha256:e4b12209b3a0bc577883fe0ac0aa3adac9e82742389f8ddb6c6b41c66b1e9c4f",
-                "sha256:e69b1c909f2eddc7ef2a24f071583bc22b73b871731ea3370ac52b3318c43b3c"
+                "sha256:5762ec9c2d59f38c76828dc1d4308baca4bc0d3e1d6f217683e7a24a1c4611a3",
+                "sha256:ee02f4b699e9b6645602a46d0adb430ee940a1bf8df64f77e516f8d7711fee60"
             ],
             "index": "pypi",
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "django-cron": {
             "hashes": [
@@ -155,11 +155,11 @@
         },
         "drf-yasg": {
             "hashes": [
-                "sha256:68fded2ffdf46e03f33e766184b7d8f1e1a5236f94acfd0c4ba932a57b812566",
-                "sha256:fcef74709ead2b365410be3d12afbfd0a6e49d1efe615a15a929da7e950bb83c"
+                "sha256:4cfec631880ae527a91ec7cd3241aea2f82189f59e2f089119aa687761afb227",
+                "sha256:504cce09035cf1bace63b84d9d778b772f86bb37d8a71ed6f723346362e633b2"
             ],
             "index": "pypi",
-            "version": "==1.16.1"
+            "version": "==1.17.0"
         },
         "elasticsearch": {
             "hashes": [
@@ -178,10 +178,10 @@
         },
         "future": {
             "hashes": [
-                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
             "index": "pypi",
-            "version": "==0.17.1"
+            "version": "==0.18.2"
         },
         "gevent": {
             "hashes": [
@@ -275,11 +275,11 @@
         },
         "ipaddress": {
             "hashes": [
-                "sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794",
-                "sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
+                "sha256:6e0f4a39e66cb5bb9a137b00276a2eff74f93b71dcbdad6f10ff7df9d3557fcc",
+                "sha256:b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2"
             ],
             "index": "pypi",
-            "version": "==1.0.22"
+            "version": "==1.0.23"
         },
         "itypes": {
             "hashes": [
@@ -371,35 +371,39 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:00fdeb23820f30e43bba78eb9abb00b7a937a655de7760b2e09101d63708b64e",
-                "sha256:01f948e8220c85eae1aa1a7f8edddcec193918f933fb07aaebe0bfbbcffefbf1",
-                "sha256:08abf39948d4b5017a137be58f1a52b7101700431f0777bec3d897c3949f74e6",
-                "sha256:099a61618b145ecb50c6f279666bbc398e189b8bc97544ae32b8fcb49ad6b830",
-                "sha256:2c1c61546e73de62747e65807d2cc4980c395d4c5600ecb1f47a650c6fa78c79",
-                "sha256:2ed9c4f694861642401f27dc3cb99772be67cd190e84845c749dae0a06c3bfae",
-                "sha256:338581b30b908e111be578f0297255f6b57a51358cd16fa0e6f664c9a1f88bff",
-                "sha256:38c7d48a21cd06fdeee93987147b9b1c55b73b4cfcbf83240568bfbd5adee447",
-                "sha256:43fd026f613c8e48a25eba1a92f4d2ad7f3903c95d8c33a11611a7717d2ab654",
-                "sha256:4548236844327a718ce3bb182ab32a16fa2050c61e334e959f554cac052fb0df",
-                "sha256:5090857876c58885cfa388dc649e5db30aae98a068c26f3fd0ac9d7d9a4d9572",
-                "sha256:5bbba34f97a26a93f5e8dec469ca4ddd712451418add43da946dbaed7f7a98d2",
-                "sha256:65a28969a025a0eb4594637b6103201dc4ed2a9508bdab56ac33e43e3081c404",
-                "sha256:892bb52b70bd5ea9dbbc3ac44f38e84f5a04e9d8b1bff48159d96cb795b81159",
-                "sha256:8a9becd5cbd5062f973bcd2e7bc79483af310222de112b6541f8af1f93a3cc42",
-                "sha256:972a7aaeb7c4a2795b52eef52ee991ef040b31009f36deca6207a986607b55f3",
-                "sha256:97b119c436bfa96a92ac2ca525f7025836d4d4e64b1c9f9eff8dbaf3ff1d86f3",
-                "sha256:9ba37698e242223f8053cc158f130aee046a96feacbeab65893dbe94f5530118",
-                "sha256:b1b0e1f626a0f079c0d3696db70132fb1f29aa87c66aecb6501a9b8be64ce9f7",
-                "sha256:c14c1224fd1a5be2733530d648a316974dbbb3c946913562c6005a76f21ca042",
-                "sha256:c79a8546c48ae6465189e54e3245a97ddf21161e33ff7eaa42787353417bb2b6",
-                "sha256:ceb76935ac4ebdf6d7bc845482a4450b284c6ccfb281e34da51d510658ab34d8",
-                "sha256:e22bffaad04b4d16e1c091baed7f2733fc1ebb91e0c602abf1b6834d17158b1f",
-                "sha256:ec883b8e44d877bda6f94a36313a1c6063f8b1997aa091628ae2f34c7f97c8d5",
-                "sha256:f1baa54d50ec031d1a9beb89974108f8f2c0706f49798f4777df879df0e1adb6",
-                "sha256:f53a5385932cda1e2c862d89460992911a89768c65d176ff8c50cddca4d29bed"
+                "sha256:047d9473cf68af50ac85f8ee5d5f21a60f849bc17d348da7fc85711287a75031",
+                "sha256:0f66dc6c8a3cc319561a633b6aa82c44107f12594643efa37210d8c924fc1c71",
+                "sha256:12c9169c4e8fe0a7329e8658c7e488001f6b4c8e88740e76292c2b857af2e94c",
+                "sha256:248cffc168896982f125f5c13e9317c059f74fffdb4152893339f3be62a01340",
+                "sha256:27faf0552bf8c260a5cee21a76e031acaea68babb64daf7e8f2e2540745082aa",
+                "sha256:285edafad9bc60d96978ed24d77cdc0b91dace88e5da8c548ba5937c425bca8b",
+                "sha256:384b12c9aa8ef95558abdcb50aada56d74bc7cc131dd62d28c2d0e4d3aadd573",
+                "sha256:38950b3a707f6cef09cd3cbb142474357ad1a985ceb44d921bdf7b4647b3e13e",
+                "sha256:4aad1b88933fd6dc2846552b89ad0c74ddbba2f0884e2c162aa368374bf5abab",
+                "sha256:4ac6148008c169603070c092e81f88738f1a0c511e07bd2bb0f9ef542d375da9",
+                "sha256:4deb1d2a45861ae6f0b12ea0a786a03d19d29edcc7e05775b85ec2877cb54c5e",
+                "sha256:59aa2c124df72cc75ed72c8d6005c442d4685691a30c55321e00ed915ad1a291",
+                "sha256:5a47d2123a9ec86660fe0e8d0ebf0aa6bc6a17edc63f338b73ea20ba11713f12",
+                "sha256:5cc901c2ab9409b4b7ac7b5bcc3e86ac14548627062463da0af3b6b7c555a871",
+                "sha256:6c1db03e8dff7b9f955a0fb9907eb9ca5da75b5ce056c0c93d33100a35050281",
+                "sha256:7ce80c0a65a6ea90ef9c1f63c8593fcd2929448613fc8da0adf3e6bfad669d08",
+                "sha256:809c19241c14433c5d6135e1b6c72da4e3b56d5c865ad5736ab99af8896b8f41",
+                "sha256:83792cb4e0b5af480588601467c0764242b9a483caea71ef12d22a0d0d6bdce2",
+                "sha256:846fa202bd7ee0f6215c897a1d33238ef071b50766339186687bd9b7a6d26ac5",
+                "sha256:9f5529fc02009f96ba95bea48870173426879dc19eec49ca8e08cd63ecd82ddb",
+                "sha256:a423c2ea001c6265ed28700df056f75e26215fd28c001e93ef4380b0f05f9547",
+                "sha256:ac4428094b42907aba5879c7c000d01c8278d451a3b7cccd2103e21f6397ea75",
+                "sha256:b1ae48d87f10d1384e5beecd169c77502fcc04a2c00a4c02b85f0a94b419e5f9",
+                "sha256:bf4e972a88f8841d8fdc6db1a75e0f8d763e66e3754b03006cbc3854d89f1cb1",
+                "sha256:c6414f6aad598364aaf81068cabb077894eb88fed99c6a65e6e8217bab62ae7a",
+                "sha256:c710fcb7ee32f67baf25aa9ffede4795fd5d93b163ce95fdc724383e38c9df96",
+                "sha256:c7be4b8a09852291c3c48d3c25d1b876d2494a0a674980089ac9d5e0d78bd132",
+                "sha256:c9e5ffb910b14f090ac9c38599063e354887a5f6d7e6d26795e916b4514f2c1a",
+                "sha256:e0697b826da6c2472bb6488db4c0a7fa8af0d52fa08833ceb3681358914b14e5",
+                "sha256:e9a3edd5f714229d41057d56ac0f39ad9bdba6767e8c888c951869f0bdd129b0"
             ],
             "index": "pypi",
-            "version": "==6.2.0"
+            "version": "==6.2.1"
         },
         "pluggy": {
             "hashes": [
@@ -410,37 +414,39 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:080c72714784989474f97be9ab0ddf7b2ad2984527e77f2909fcd04d4df53809",
-                "sha256:110457be80b63ff4915febb06faa7be002b93a76e5ba19bf3f27636a2ef58598",
-                "sha256:171352a03b22fc099f15103959b52ee77d9a27e028895d7e5fde127aa8e3bac5",
-                "sha256:19d013e7b0817087517a4b3cab39c084d78898369e5c46258aab7be4f233d6a1",
-                "sha256:249b6b21ae4eb0f7b8423b330aa80fab5f821b9ffc3f7561a5e2fd6bb142cf5d",
-                "sha256:2ac0731d2d84b05c7bb39e85b7e123c3a0acd4cda631d8d542802c88deb9e87e",
-                "sha256:2b6d561193f0dc3f50acfb22dd52ea8c8dfbc64bcafe3938b5f209cc17cb6f00",
-                "sha256:2bd23e242e954214944481124755cbefe7c2cf563b1a54cd8d196d502f2578bf",
-                "sha256:3e1239242ca60b3725e65ab2f13765fc199b03af9eaf1b5572f0e97bdcee5b43",
-                "sha256:3eb70bb697abbe86b1d2b1316370c02ba320bfd1e9e35cf3b9566a855ea8e4e5",
-                "sha256:51a2fc7e94b98bd1bb5d4570936f24fc2b0541b63eccadf8fdea266db8ad2f70",
-                "sha256:52f1bdafdc764b7447e393ed39bb263eccb12bfda25a4ac06d82e3a9056251f6",
-                "sha256:5b3581319a3951f1e866f4f6c5e42023db0fae0284273b82e97dfd32c51985cd",
-                "sha256:63c1b66e3b2a3a336288e4bcec499e0dc310cd1dceaed1c46fa7419764c68877",
-                "sha256:8123a99f24ecee469e5c1339427bcdb2a33920a18bb5c0d58b7c13f3b0298ba3",
-                "sha256:85e699fcabe7f817c0f0a412d4e7c6627e00c412b418da7666ff353f38e30f67",
-                "sha256:8dbff4557bbef963697583366400822387cccf794ccb001f1f2307ed21854c68",
-                "sha256:908d21d08d6b81f1b7e056bbf40b2f77f8c499ab29e64ec5113052819ef1c89b",
-                "sha256:af39d0237b17d0a5a5f638e9dffb34013ce2b1d41441fd30283e42b22d16858a",
-                "sha256:af51bb9f055a3f4af0187149a8f60c9d516cf7d5565b3dac53358796a8fb2a5b",
-                "sha256:b2ecac57eb49e461e86c092761e6b8e1fd9654dbaaddf71a076dcc869f7014e2",
-                "sha256:cd37cc170678a4609becb26b53a2bc1edea65177be70c48dd7b39a1149cabd6e",
-                "sha256:d17e3054b17e1a6cb8c1140f76310f6ede811e75b7a9d461922d2c72973f583e",
-                "sha256:d305313c5a9695f40c46294d4315ed3a07c7d2b55e48a9010dad7db7a66c8b7f",
-                "sha256:dd0ef0eb1f7dd18a3f4187226e226a7284bda6af5671937a221766e6ef1ee88f",
-                "sha256:e1adff53b56db9905db48a972fb89370ad5736e0450b96f91bcf99cadd96cfd7",
-                "sha256:f0d43828003c82dbc9269de87aa449e9896077a71954fbbb10a614c017e65737",
-                "sha256:f78e8b487de4d92640105c1389e5b90be3496b1d75c90a666edd8737cc2dbab7"
+                "sha256:040234f8a4a8dfd692662a8308d78f63f31a97e1c42d2480e5e6810c48966a29",
+                "sha256:086f7e89ec85a6704db51f68f0dcae432eff9300809723a6e8782c41c2f48e03",
+                "sha256:18ca813fdb17bc1db73fe61b196b05dd1ca2165b884dd5ec5568877cabf9b039",
+                "sha256:19dc39616850342a2a6db70559af55b22955f86667b5f652f40c0e99253d9881",
+                "sha256:2166e770cb98f02ed5ee2b0b569d40db26788e0bf2ec3ae1a0d864ea6f1d8309",
+                "sha256:3a2522b1d9178575acee4adf8fd9f979f9c0449b00b4164bb63c3475ea6528ed",
+                "sha256:3aa773580f85a28ffdf6f862e59cb5a3cc7ef6885121f2de3fca8d6ada4dbf3b",
+                "sha256:3b5deaa3ee7180585a296af33e14c9b18c218d148e735c7accf78130765a47e3",
+                "sha256:407af6d7e46593415f216c7f56ba087a9a42bd6dc2ecb86028760aa45b802bd7",
+                "sha256:4c3c09fb674401f630626310bcaf6cd6285daf0d5e4c26d6e55ca26a2734e39b",
+                "sha256:4c6717962247445b4f9e21c962ea61d2e884fc17df5ddf5e35863b016f8a1f03",
+                "sha256:50446fae5681fc99f87e505d4e77c9407e683ab60c555ec302f9ac9bffa61103",
+                "sha256:5057669b6a66aa9ca118a2a860159f0ee3acf837eda937bdd2a64f3431361a2d",
+                "sha256:5dd90c5438b4f935c9d01fcbad3620253da89d19c1f5fca9158646407ed7df35",
+                "sha256:659c815b5b8e2a55193ede2795c1e2349b8011497310bb936da7d4745652823b",
+                "sha256:69b13fdf12878b10dc6003acc8d0abf3ad93e79813fd5f3812497c1c9fb9be49",
+                "sha256:7a1cb80e35e1ccea3e11a48afe65d38744a0e0bde88795cc56a4d05b6e4f9d70",
+                "sha256:7e6e3c52e6732c219c07bd97fff6c088f8df4dae3b79752ee3a817e6f32e177e",
+                "sha256:7f42a8490c4fe854325504ce7a6e4796b207960dabb2cbafe3c3959cb00d1d7e",
+                "sha256:84156313f258eafff716b2961644a4483a9be44a5d43551d554844d15d4d224e",
+                "sha256:8578d6b8192e4c805e85f187bc530d0f52ba86c39172e61cd51f68fddd648103",
+                "sha256:890167d5091279a27e2505ff0e1fb273f8c48c41d35c5b92adbf4af80e6b2ed6",
+                "sha256:9aadff9032e967865f9778485571e93908d27dab21d0fdfdec0ca779bb6f8ad9",
+                "sha256:9f24f383a298a0c0f9b3113b982e21751a8ecde6615494a3f1470eb4a9d70e9e",
+                "sha256:a73021b44813b5c84eda4a3af5826dd72356a900bac9bd9dd1f0f81ee1c22c2f",
+                "sha256:afd96845e12638d2c44d213d4810a08f4dc4a563f9a98204b7428e567014b1cd",
+                "sha256:b73ddf033d8cd4cc9dfed6324b1ad2a89ba52c410ef6877998422fcb9c23e3a8",
+                "sha256:dbc5cd56fff1a6152ca59445178652756f4e509f672e49ccdf3d79c1043113a4",
+                "sha256:eac8a3499754790187bb00574ab980df13e754777d346f85e0ff6df929bcd964",
+                "sha256:eaed1c65f461a959284649e37b5051224f4db6ebdc84e40b5e65f2986f101a08"
             ],
             "index": "pypi",
-            "version": "==2.8.3"
+            "version": "==2.8.4"
         },
         "py": {
             "hashes": [
@@ -459,32 +465,32 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:0961bf3429691b9cd7e3695a37ee8bc18e95c56ac1271dc2bbc41697062d1b6d",
+                "sha256:8997c62f779045b07273e124bbe1d03e2eebb9a38a7ef0798fea4bae72b4b6a3"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.3"
         },
         "pytest": {
             "hashes": [
-                "sha256:7e4800063ccfc306a53c461442526c5571e1462f61583506ce97e4da6a1d88c8",
-                "sha256:ca563435f4941d0cb34767301c27bc65c510cb82e90b9ecf9cb52dc2c63caaa0"
+                "sha256:27abc3fef618a01bebb1f0d6d303d2816a99aa87a5968ebc32fe971be91eb1e6",
+                "sha256:58cee9e09242937e136dbb3dab466116ba20d6b7828c7620f23947f37eb4dae4"
             ],
-            "version": "==5.2.1"
+            "version": "==5.2.2"
         },
         "pytest-django": {
             "hashes": [
-                "sha256:264fb4c506db5d48a6364c311a0b00b7b48a52715bad8839b2d8bee9b99ed6bb",
-                "sha256:4adfe5fb3ed47f0ba55506dd3daf688b1f74d5e69148c10ad2dd2f79f40c0d62"
+                "sha256:497e8d967d2ec82b3388267b2f1f037761ff34c10ebb13c534d8c5804846e4eb",
+                "sha256:b6c900461a6a7c450dcf11736cabc289a90f5d6f28ef74c46e32e86ffd16a4bd"
             ],
             "index": "pypi",
-            "version": "==3.5.1"
+            "version": "==3.6.0"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
-                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "version": "==2.8.0"
+            "version": "==2.8.1"
         },
         "python-slugify": {
             "hashes": [
@@ -576,10 +582,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "sqlparse": {
             "hashes": [
@@ -650,18 +656,18 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
-                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+                "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
+                "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
             ],
-            "version": "==4.4.0"
+            "version": "==4.4.1"
         },
         "ipython": {
             "hashes": [
-                "sha256:c4ab005921641e40a68e405e286e7a1fcc464497e14d81b6914b4fd95e5dee9b",
-                "sha256:dd76831f065f17bddd7eaa5c781f5ea32de5ef217592cf019e34043b56895aa1"
+                "sha256:dfd303b270b7b5232b3d08bd30ec6fd685d8a58cabd54055e3d69d8f029f7280",
+                "sha256:ed7ebe1cba899c1c3ccad6f7f1c2d2369464cc77dba8eebc65e2043e19cda995"
             ],
             "index": "pypi",
-            "version": "==7.8.0"
+            "version": "==7.9.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -748,10 +754,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "traitlets": {
             "hashes": [

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -449,43 +449,25 @@ def _elasticsearch_connect():
 
     :return: An Elasticsearch connection object.
     """
-    try:
-        log.info('Trying to connect to Elasticsearch without authentication...')
-        # Try to connect to Elasticsearch without credentials.
-        _es = Elasticsearch(
-            host=settings.ELASTICSEARCH_URL,
-            port=settings.ELASTICSEARCH_PORT,
-            connection_class=RequestsHttpConnection,
-            timeout=10,
-            max_retries=99,
-            wait_for_status='yellow'
-        )
-        log.info(str(_es.info()))
-        log.info('Connected to Elasticsearch without authentication.')
-    except (AuthenticationException, AuthorizationException):
-        # If that fails, supply AWS authentication object and try again.
-        log.info(
-            'Connecting to %s %s with AWS auth', settings.ELASTICSEARCH_URL,
-            settings.ELASTICSEARCH_PORT)
-        auth = AWSRequestsAuth(
-            aws_access_key=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            aws_host=settings.ELASTICSEARCH_URL,
-            aws_region=settings.ELASTICSEARCH_AWS_REGION,
-            aws_service='es'
-        )
-        auth.encode = lambda x: bytes(x.encode('utf-8'))
-        _es = Elasticsearch(
-            host=settings.ELASTICSEARCH_URL,
-            port=settings.ELASTICSEARCH_PORT,
-            connection_class=RequestsHttpConnection,
-            timeout=10,
-            max_retries=99,
-            retry_on_timeout=True,
-            http_auth=auth,
-            wait_for_status='yellow'
-        )
-        _es.info()
+    auth = AWSRequestsAuth(
+        aws_access_key=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        aws_host=settings.ELASTICSEARCH_URL,
+        aws_region=settings.ELASTICSEARCH_AWS_REGION,
+        aws_service='es'
+    )
+    auth.encode = lambda x: bytes(x.encode('utf-8'))
+    _es = Elasticsearch(
+        host=settings.ELASTICSEARCH_URL,
+        port=settings.ELASTICSEARCH_PORT,
+        connection_class=RequestsHttpConnection,
+        timeout=10,
+        max_retries=99,
+        retry_on_timeout=True,
+        http_auth=auth,
+        wait_for_status='yellow'
+    )
+    _es.info()
     return _es
 
 

--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -286,7 +286,7 @@ class ImageSerializer(serializers.Serializer):
     thumbnail = serializers.URLField(required=False, allow_blank=True)
     provider = serializers.CharField(required=False)
     source = serializers.CharField(required=False)
-    license = serializers.CharField()
+    license = serializers.SerializerMethodField()
     license_version = serializers.CharField(required=False)
     foreign_landing_url = serializers.URLField(required=False)
     meta_data = serializers.CharField(required=False)
@@ -306,6 +306,9 @@ class ImageSerializer(serializers.Serializer):
         required=False,
         help_text="The width of the image in pixels. Not always available."
     )
+
+    def get_license(self, obj):
+        return obj.license.lower()
 
 
 class RelatedImagesResultsSerializer(serializers.Serializer):

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -280,8 +280,8 @@ ELASTICSEARCH_URL = os.environ.get('ELASTICSEARCH_URL', 'localhost')
 ELASTICSEARCH_PORT = int(os.environ.get('ELASTICSEARCH_PORT', 9200))
 
 # Additional settings for dev/prod environments
-AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
-AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
 ELASTICSEARCH_AWS_REGION = \
     os.environ.get('ELASTICSEARCH_AWS_REGION', 'us-east-1')
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,13 +31,14 @@ services:
       test: "pg_isready -U deploy -d openledger"
 
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.1.0
     ports:
       - "9200:9200"
     environment:
       # disable XPack
       # https://www.elastic.co/guide/en/elasticsearch/reference/5.3/docker.html#_security_note
       - xpack.security.enabled=false
+      - discovery.type=single-node
     healthcheck:
       test: ["CMD-SHELL", "curl -si -XGET 'localhost:9200/_cluster/health?pretty' | grep -qE 'yellow|green'"]
       interval: 10s

--- a/ingestion_server/Pipfile
+++ b/ingestion_server/Pipfile
@@ -12,7 +12,7 @@ pycodestyle = "*"
 [packages]
 aws-requests-auth = "*"
 bottle="*"
-elasticsearch-dsl = "==6.3.1"
+elasticsearch-dsl = "==7.0.0"
 falcon="*"
 gunicorn="*"
 psycopg2-binary = "*"

--- a/ingestion_server/Pipfile.lock
+++ b/ingestion_server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8521543791ad461786b7ae478c8d817a2e08a4a4acc91e69fbdd572c8371822d"
+            "sha256": "fabc8e5c4f13db77cbe28b54b877c05104731896deb2bf96a7cf6afc9cd026d5"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,18 +23,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:839285fbd6f3ab16170af449ae9e33d0eccf97ca22de17d9ff68b8da2310ea06",
-                "sha256:d93f1774c4bc66e02acdda2067291acb9e228a035435753cb75f83ad2904cbe3"
+                "sha256:08d949fede71c14db8b9b638edaa13831d79daed84e2da27750629fd606bdb57",
+                "sha256:4d7c2cc266917cd0ff7e5e039158de80991e21696a2e8bf85201de2d06d7ceea"
             ],
             "index": "pypi",
-            "version": "==1.9.253"
+            "version": "==1.10.9"
         },
         "botocore": {
             "hashes": [
-                "sha256:3baf129118575602ada9926f5166d82d02273c250d0feb313fc270944b27c48b",
-                "sha256:dc080aed4f9b220a9e916ca29ca97a9d37e8e1d296fe89cbaeef929bf0c8066b"
+                "sha256:61ad58e737e7a5d61308599606cd5a435cc3b97eb7fa693f99663c91bf1706d1",
+                "sha256:8cb038c110822681925a1f5d9005dc2bbc4259fff89d4abfaaf803a3489d0ee3"
             ],
-            "version": "==1.12.253"
+            "version": "==1.13.9"
         },
         "bottle": {
             "hashes": [
@@ -68,18 +68,18 @@
         },
         "elasticsearch": {
             "hashes": [
-                "sha256:1f0f633e3b500d5042424f75a505badf8c4b9962c1b4734cdfb3087fb67920be",
-                "sha256:fb5ab15ee283f104b5a7a5695c7e879cb2927e4eb5aed9c530811590b41259ad"
+                "sha256:693935914d59a517dfffdaab547ff906712a386d9e25027517464960221cbd4c",
+                "sha256:7644fa0a9ae524344185bda561826a781a5c6bd4d3eb98a24515c567aab88327"
             ],
-            "version": "==6.4.0"
+            "version": "==7.0.5"
         },
         "elasticsearch-dsl": {
             "hashes": [
-                "sha256:5f43196a3fd91b2eac90f7345e99f92c66004d85a1fd803cdecf756430827231",
-                "sha256:5f80b3b4a6e61db5d273bc57c32a80b2ddbc555afcc122c62c20440c355008be"
+                "sha256:2aedc2a4dbba9870249a57d1798ec29e44404619bded66ac920f5d6a1cbb6f22",
+                "sha256:763fb28add254f2c3a1d071cd114466d8a27f640e02a874afba7b8a04147c094"
             ],
             "index": "pypi",
-            "version": "==6.3.1"
+            "version": "==7.0.0"
         },
         "falcon": {
             "hashes": [
@@ -217,11 +217,11 @@
         },
         "tld": {
             "hashes": [
-                "sha256:89a7a403a4a5de1ca7b64550df8a8a2abdfbbd1556e1b8cdfe251c0f90ab2f3a",
-                "sha256:e63acad4f866bc4c724a21a03eb7cf692bc8495cb286ee60d3a45258054bdc02"
+                "sha256:1c0020fac141d14ee43d7e55aa54cc605515b37d472e5e5612d21196ca89e3be",
+                "sha256:cef15360ec42547a583d49ef5246936b3ace424a95c00b59c09dcbe44b289961"
             ],
             "index": "pypi",
-            "version": "==0.9.6"
+            "version": "==0.9.7"
         },
         "urllib3": {
             "hashes": [
@@ -242,18 +242,18 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
-                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+                "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
+                "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
             ],
-            "version": "==4.4.0"
+            "version": "==4.4.1"
         },
         "ipython": {
             "hashes": [
-                "sha256:c4ab005921641e40a68e405e286e7a1fcc464497e14d81b6914b4fd95e5dee9b",
-                "sha256:dd76831f065f17bddd7eaa5c781f5ea32de5ef217592cf019e34043b56895aa1"
+                "sha256:dfd303b270b7b5232b3d08bd30ec6fd685d8a58cabd54055e3d69d8f029f7280",
+                "sha256:ed7ebe1cba899c1c3ccad6f7f1c2d2369464cc77dba8eebc65e2043e19cda995"
             ],
             "index": "pypi",
-            "version": "==7.8.0"
+            "version": "==7.9.0"
         },
         "ipython-genutils": {
             "hashes": [

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -3,7 +3,6 @@ import time
 import multiprocessing
 import uuid
 import requests as re
-import psycopg2
 from psycopg2.extras import DictCursor, Json
 from ingestion_server.indexer import database_connect, DB_BUFFER_SIZE
 from urllib.parse import urlparse
@@ -235,7 +234,7 @@ def _clean_data_worker(rows, temp_table, providers_config):
     return True
 
 
-def clean_image_data(table, upstream_db):
+def clean_image_data(table):
     """
     Data from upstream can be unsuitable for production for a number of reasons.
     Clean it up before we go live with the new data.

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -108,7 +108,7 @@ class Image(SyncableDocType):
             views = int(metrics['views'])
             likes = int(metrics['likes'])
             comments = int(metrics['comments'])
-        except KeyError:
+        except (KeyError, TypeError):
             pass
         return Image(
             _id=row[schema['id']],

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -1,5 +1,4 @@
-from elasticsearch_dsl import Date, Text, Integer, Nested, Keyword, DocType
-from elasticsearch_dsl.query import Query
+from elasticsearch_dsl import Date, Text, Integer, Keyword, DocType, Field
 
 """
 Provides an ORM-like experience for accessing data in Elasticsearch.
@@ -9,7 +8,7 @@ low-level changes to the index must be represented there as well.
 """
 
 
-class RankFeature(Query):
+class RankFeature(Field):
     name = 'rank_feature'
 
 
@@ -100,14 +99,12 @@ class Image(SyncableDocType):
             else:
                 return None
 
-        views = None
-        comments = None
-        likes = None
+        views, comments, likes = None, None, None
         try:
             metrics = row[schema['meta_data']]['popularity_metrics']
-            views = int(metrics['views'])
-            likes = int(metrics['likes'])
-            comments = int(metrics['comments'])
+            views = int(metrics['views']) + 1
+            likes = int(metrics['likes']) + 1
+            comments = int(metrics['comments']) + 1
         except (KeyError, TypeError):
             pass
         return Image(

--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -8,143 +8,150 @@ def create_mapping(table_name):
     mapping = {
         'image': {
            "mappings": {
-               "doc": {
-                   "properties": {
-                      "license_version": {
-                         "type": "text",
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         }
-                      },
-                      "view_count": {
-                         "type": "long"
-                      },
-                      "provider": {
-                         "type": "text",
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         }
-                      },
-                      "source": {
-                         "fields": {
-                            "keyword": {
-                               "ignore_above": 256,
-                               "type": "keyword"
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "license": {
-                         "fields": {
-                            "keyword": {
-                               "ignore_above": 256,
-                               "type": "keyword"
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "url": {
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "tags": {
-                         "properties": {
-                            "accuracy": {
-                               "type": "float"
-                            },
-                            "name": {
-                               "type": "text",
-                               "fields": {
-                                  "keyword": {
-                                     "type": "keyword",
-                                     "ignore_above": 256
-                                  }
-                               },
-                               "analyzer": "english"
-                            }
-                         }
-                      },
-                      "foreign_landing_url": {
-                         "fields": {
-                            "keyword": {
-                               "ignore_above": 256,
-                               "type": "keyword"
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "id": {
-                         "type": "long"
-                      },
-                      "identifier": {
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         },
-                         "type": "text"
-                      },
-                      "title": {
-                         "type": "text",
-                         "similarity": "boolean",
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         },
-                         "analyzer": "english"
-                      },
-                      "creator": {
-                         "type": "text",
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "ignore_above": 256
-                            }
-                         }
-                      },
-                      "created_on": {
-                         "type": "date"
-                      },
-                      "description": {
-                         "fields": {
-                            "keyword": {
-                               "type": "keyword",
-                               "similarity": "boolean"
-                            }
-                         },
-                         "type": "text",
-                         "analyzer": "english"
-                      },
-                      "height": {
-                         "type": "integer"
-                      },
-                      "width": {
-                         "type": "integer"
-                      },
-                      "extension": {
-                         "fields": {
-                            "keyword": {
-                               "ignore_above": 8,
-                               "type": "keyword"
-                            }
-                         },
-                         "type": "text"
-                      },
-                   }
+               "properties": {
+                  "license_version": {
+                     "type": "text",
+                     "fields": {
+                        "keyword": {
+                           "type": "keyword",
+                           "ignore_above": 256
+                        }
+                     }
+                  },
+                  "view_count": {
+                     "type": "long"
+                  },
+                  "provider": {
+                     "type": "text",
+                     "fields": {
+                        "keyword": {
+                           "type": "keyword",
+                           "ignore_above": 256
+                        }
+                     }
+                  },
+                  "source": {
+                     "fields": {
+                        "keyword": {
+                           "ignore_above": 256,
+                           "type": "keyword"
+                        }
+                     },
+                     "type": "text"
+                  },
+                  "license": {
+                     "fields": {
+                        "keyword": {
+                           "ignore_above": 256,
+                           "type": "keyword"
+                        }
+                     },
+                     "type": "text"
+                  },
+                  "url": {
+                     "fields": {
+                        "keyword": {
+                           "type": "keyword",
+                           "ignore_above": 256
+                        }
+                     },
+                     "type": "text"
+                  },
+                  "tags": {
+                     "properties": {
+                        "accuracy": {
+                           "type": "float"
+                        },
+                        "name": {
+                           "type": "text",
+                           "fields": {
+                              "keyword": {
+                                 "type": "keyword",
+                                 "ignore_above": 256
+                              }
+                           },
+                           "analyzer": "english"
+                        }
+                     }
+                  },
+                  "foreign_landing_url": {
+                     "fields": {
+                        "keyword": {
+                           "ignore_above": 256,
+                           "type": "keyword"
+                        }
+                     },
+                     "type": "text"
+                  },
+                  "id": {
+                     "type": "long"
+                  },
+                  "identifier": {
+                     "fields": {
+                        "keyword": {
+                           "type": "keyword",
+                           "ignore_above": 256
+                        }
+                     },
+                     "type": "text"
+                  },
+                  "title": {
+                     "type": "text",
+                     "similarity": "boolean",
+                     "fields": {
+                        "keyword": {
+                           "type": "keyword",
+                           "ignore_above": 256
+                        }
+                     },
+                     "analyzer": "english"
+                  },
+                  "creator": {
+                     "type": "text",
+                     "fields": {
+                        "keyword": {
+                           "type": "keyword",
+                           "ignore_above": 256
+                        }
+                     }
+                  },
+                  "created_on": {
+                     "type": "date"
+                  },
+                  "description": {
+                     "fields": {
+                        "keyword": {
+                           "type": "keyword",
+                           "similarity": "boolean"
+                        }
+                     },
+                     "type": "text",
+                     "analyzer": "english"
+                  },
+                  "height": {
+                     "type": "integer"
+                  },
+                  "width": {
+                     "type": "integer"
+                  },
+                  "extension": {
+                     "fields": {
+                        "keyword": {
+                           "ignore_above": 8,
+                           "type": "keyword"
+                        }
+                     },
+                     "type": "text"
+                  },
+                  "views": {
+                     "type": "rank_feature"
+                  },
+                  "likes": {
+                     "type": "rank_feature"
+                  },
+                  "comments": {
+                     "type": "rank_feature"
+                  },
                }
            }
         }

--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -151,7 +151,7 @@ def create_mapping(table_name):
                   },
                   "comments": {
                      "type": "rank_feature"
-                  },
+                  }
                }
            }
         }

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -362,6 +362,10 @@ class TableIndexer:
         suffix = uuid.uuid4().hex
         destination_index = model_name + '-' + suffix
         if distributed:
+            self.es.indices.create(
+                index=destination_index,
+                body=create_mapping(model_name)
+            )
             schedule_distributed_index(database_connect(), destination_index)
         else:
             self._index_table(model_name, dest_idx=destination_index)

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -264,12 +264,7 @@ def reload_upstream(table, progress=None, finish_time=None):
         downstream_cur.execute(copy_data)
     downstream_db.commit()
     downstream_db.close()
-    upstream_info = {
-        'port': UPSTREAM_DB_PORT,
-        'password': UPSTREAM_DB_PASSWORD,
-        'host': UPSTREAM_DB_HOST
-    }
-    clean_image_data(table, upstream_info)
+    clean_image_data(table)
     log.info('Cleaning step finished.')
     downstream_db = database_connect()
     with downstream_db.cursor() as downstream_cur:

--- a/misc/README.md
+++ b/misc/README.md
@@ -1,0 +1,2 @@
+Assorted scripts for data munging that don't belong anywhere else. These are 
+kept for historical reasons and don't need to be maintained going forward.

--- a/misc/gen_popularity.py
+++ b/misc/gen_popularity.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import random
 import seaborn as sbn
 import numpy as np
 
@@ -18,7 +19,7 @@ def gen_dist(_max):
 
 likes, views, comments = gen_dist(1000000), gen_dist(4000000), gen_dist(30000)
 
-with open('sample_data.csv') as _csv, open('enriched.csv', 'w+') as out:
+with open('../sample_data.csv') as _csv, open('enriched.csv', 'w+') as out:
     reader = csv.DictReader(_csv)
     writer = csv.DictWriter(out, fieldnames=reader.fieldnames)
     writer.writeheader()
@@ -26,7 +27,9 @@ with open('sample_data.csv') as _csv, open('enriched.csv', 'w+') as out:
     for idx, row in enumerate(reader):
         metadata = json.loads(row['meta_data'])
         fake = {'likes': likes[idx], 'views': views[idx], 'comments': comments[idx]}
-        metadata['popularity_metrics'] = fake
-        row['meta_data'] = json.dumps(metadata)
+        # In the real world, this data is missing frequently. Omit it for some records.
+        if random.choice([True, False]):
+            metadata['popularity_metrics'] = fake
+            row['meta_data'] = json.dumps(metadata)
         writer.writerow(row)
 

--- a/misc/gen_popularity.py
+++ b/misc/gen_popularity.py
@@ -1,0 +1,32 @@
+import csv
+import json
+import seaborn as sbn
+import numpy as np
+
+"""
+Add a popularity_metrics column with some fake data into the sample data CSV.
+"""
+
+def gen_dist(_max):
+    num_samples = 5000
+    population = np.random.pareto(num_samples, num_samples)
+    highest = max(population)
+    scale = _max / highest
+    _sorted = sorted(population * scale)
+    return [int(n) for n in _sorted]
+
+
+likes, views, comments = gen_dist(1000000), gen_dist(4000000), gen_dist(30000)
+
+with open('sample_data.csv') as _csv, open('enriched.csv', 'w+') as out:
+    reader = csv.DictReader(_csv)
+    writer = csv.DictWriter(out, fieldnames=reader.fieldnames)
+    writer.writeheader()
+    enriched = []
+    for idx, row in enumerate(reader):
+        metadata = json.loads(row['meta_data'])
+        fake = {'likes': likes[idx], 'views': views[idx], 'comments': comments[idx]}
+        metadata['popularity_metrics'] = fake
+        row['meta_data'] = json.dumps(metadata)
+        writer.writerow(row)
+


### PR DESCRIPTION
Index popularity data in Elasticsearch and use it as a ranking factor if POPULARITY_BOOST is enabled (disabled by default for now).

Some providers give us stats like "views", "comments", and "likes", which we can use as a ranking factor. This is expected to be stored in the `meta_data` field in Postgres under the key `popularity_metrics`.

We're going to need popularity data in production for at least one provider in order to be able to fine-tune it in a useful way (adjusting boost factor and other parameters, preventing non-social results from being drowned out, comparing with/without popularity boosting in our dev environment). All of that is blocking on pulling popularity data and writing it to the `meta_data` column in creativecommons/cccatalog. I expect to have to do some additional fine-tuning of this feature once that data is available in order to make this production ready.