### PR TITLE
Fix broken PDM license link

### DIFF
--- a/cccatalog-api/cccatalog/api/licenses.py
+++ b/cccatalog-api/cccatalog/api/licenses.py
@@ -24,7 +24,6 @@ LICENSE_GROUPS = {
 ATTRIBUTION = \
     "{title} {creator}is licensed under CC-{_license} {version}. To view a " \
     "copy of this license, visit {license_url}."
-LICENSE_URL = 'https://creativecommons.org/licenses/{_license}/{version}/'
 
 
 def get_license_url(_license, version):

--- a/cccatalog-api/cccatalog/api/licenses.py
+++ b/cccatalog-api/cccatalog/api/licenses.py
@@ -25,3 +25,10 @@ ATTRIBUTION = \
     "{title} {creator}is licensed under CC-{_license} {version}. To view a " \
     "copy of this license, visit {license_url}."
 LICENSE_URL = 'https://creativecommons.org/licenses/{_license}/{version}/'
+
+
+def get_license_url(_license, version):
+    if _license.lower() == 'pdm':
+        return 'https://creativecommons.org/publicdomain/mark/1.0/'
+    else:
+        return f'https://creativecommons.org/licenses/{_license}/{version}/'

--- a/cccatalog-api/cccatalog/api/models.py
+++ b/cccatalog-api/cccatalog/api/models.py
@@ -2,7 +2,7 @@ from uuslug import uuslug
 from django.db import models
 from django.utils.safestring import mark_safe
 from django.contrib.postgres.fields import JSONField, ArrayField
-from cccatalog.api.licenses import ATTRIBUTION, LICENSE_URL
+from cccatalog.api.licenses import ATTRIBUTION, get_license_url
 from oauth2_provider.models import AbstractApplication
 
 
@@ -111,10 +111,7 @@ class Image(OpenLedgerModel):
     def license_url(self):
         _license = str(self.license)
         license_version = str(self.license_version)
-        return LICENSE_URL.format(
-            _license=_license,
-            version=license_version
-        )
+        return get_license_url(_license, license_version)
 
     @property
     def attribution(self):


### PR DESCRIPTION
Fixes https://github.com/creativecommons/cccatalog-api/issues/384

PDM license links aren't formatted like the others; add a special exception for linking to the PDM deed.