### PR TITLE
Return license URL in search response

### DIFF
--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -37,10 +37,6 @@ class ImageDetailSerializer(ModelSerializer, ImageSerializer):
                   "give credit to creators to their works and fulfill "
                   "legal attribution requirements."
     )
-    license_url = serializers.URLField(
-        required=True,
-        help_text="The URL leading to the license associated with the work."
-    )
     tags = ImageDetailTagSerializer(
         many=True,
         help_text="Tags with detailed metadata, such as accuracy and provider."


### PR DESCRIPTION
Fixes #387.

Return the `license_url` in search endpoint in addition to image detail views.