### PR TITLE
Remove redundant image category

### DIFF
--- a/cccatalog-api/cccatalog/api/serializers/search_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/search_serializers.py
@@ -197,7 +197,7 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
     categories = serializers.CharField(
         label="categories",
         help_text="A comma separated list of categories; available categories "
-                  "include `vector`, `illustration`, `photograph`, and "
+                  "include `illustration`, `photograph`, and "
                   "`digitized_artwork`.",
         required=False
     )
@@ -210,7 +210,7 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
     size = serializers.CharField(
         label='size',
         help_text="A comma separated list of image sizes; available sizes"
-                  "include `small`, medium, or `large`.",
+                  "include `small`, `medium`, or `large`.",
         required=False
     )
     qa = serializers.BooleanField(
@@ -278,7 +278,6 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
     @staticmethod
     def validate_categories(value):
         valid_categories = {
-            'vector',
             'illustration',
             'digitized_artwork',
             'photograph'

--- a/ingestion_server/ingestion_server/categorize.py
+++ b/ingestion_server/ingestion_server/categorize.py
@@ -1,4 +1,4 @@
-import enum
+from enum import Enum, auto
 
 """
 https://github.com/creativecommons/cccatalog-api/issues/340
@@ -8,19 +8,18 @@ digitized artwork) based on its source and file extension.
 """
 
 
-class Category(enum.Enum):
-    VECTOR = 0
-    PHOTOGRAPH = 1
-    DIGITIZED_ARTWORK = 2
-    ILLUSTRATION = 3
+class Category(Enum):
+    PHOTOGRAPH = auto()
+    DIGITIZED_ARTWORK = auto()
+    ILLUSTRATION = auto()
 
 
 # Map each provider to a set of categories..
 provider_category = {
     '__default': [],
     'thorvaldsenmuseum': [Category.DIGITIZED_ARTWORK],
-    'svgsilh': [Category.VECTOR, Category.ILLUSTRATION],
-    'phylopic': [Category.VECTOR, Category.ILLUSTRATION],
+    'svgsilh': [Category.ILLUSTRATION],
+    'phylopic': [Category.ILLUSTRATION],
     'floraon': [Category.PHOTOGRAPH],
     'animaldiversity': [Category.PHOTOGRAPH],
     'WoRMS': [Category.PHOTOGRAPH],
@@ -39,7 +38,7 @@ provider_category = {
 
 def get_categories(extension, provider):
     if extension and extension.lower() == 'svg':
-        categories = [Category.VECTOR, Category.ILLUSTRATION]
+        categories = [Category.ILLUSTRATION]
     elif provider in provider_category:
         categories = provider_category[provider]
     else:

--- a/ingestion_server/test/unit_tests.py
+++ b/ingestion_server/test/unit_tests.py
@@ -90,6 +90,9 @@ class TestCleanup:
                 'name': 'cc0'
             },
             {
+                'name': ' cc0'
+            },
+            {
                 'name': 'valid',
                 'accuracy': 0.99
             },


### PR DESCRIPTION
Related to #340 

Remove the `vector` category described in the requirements for #340; it's exactly equivalent to `illustration`.