### PR TITLE
Handles search phase execution exceptions

### DIFF
--- a/cccatalog-api/cccatalog/api/utils/exceptions.py
+++ b/cccatalog-api/cccatalog/api/utils/exceptions.py
@@ -9,7 +9,13 @@ production web server configuration, and not reproducible locally.
 """
 
 
-def input_error_response(errors):
+def parse_value_errors(errors):
+    field = 'q'
+    message = errors.args[0].info['error']['root_cause'][0]['reason']
+    return field, message
+
+
+def parse_non_value_errors(errors):
     field = [f for f in errors]
     messages = []
     for _field in errors:
@@ -24,6 +30,15 @@ def input_error_response(errors):
         split_error = messages.split(' ')
         field_idx = messages.index('Parameter') + 1
         field = [split_error[field_idx].replace("'", '')][0]
+
+    return field, messages
+
+
+def input_error_response(errors):
+    if isinstance(errors, ValueError):
+        field, messages = parse_value_errors(errors)
+    else:
+        field, messages = parse_non_value_errors(errors)
 
     return Response(
         status=status.HTTP_400_BAD_REQUEST,

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -85,7 +85,7 @@ class SearchImages(APIView):
                 page=page_param
             )
         except ValueError as value_error:
-            return input_error_response(str(value_error))
+            return input_error_response(value_error)
 
         context = {'request': request}
         serialized_results = ImageSerializer(


### PR DESCRIPTION
Handles search phase execution exceptions that throws an error 500, instead of an InputError.

Fixes [406](https://github.com/creativecommons/cccatalog-api/issues/406)

Without handling the errors, the API crashes.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

