### PR TITLE
Correctly handle international jurisdiction license URLs

### DIFF
--- a/cccatalog-api/cccatalog/api/licenses.py
+++ b/cccatalog-api/cccatalog/api/licenses.py
@@ -26,7 +26,9 @@ ATTRIBUTION = \
     "copy of this license, visit {license_url}."
 
 
-def get_license_url(_license, version):
+def get_license_url(_license, version, meta_data=None):
+    if meta_data and 'license_url' in meta_data:
+        return meta_data['license_url']
     if _license.lower() == 'pdm':
         return 'https://creativecommons.org/publicdomain/mark/1.0/'
     else:

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -321,7 +321,20 @@ class ImageSerializer(serializers.Serializer):
         return obj.license.lower()
 
     def get_license_url(self, obj):
-        return license_helpers.get_license_url(obj.license, obj.license_version)
+        import logging as log
+        if hasattr(obj, 'meta_data'):
+            log.info('found license in metadata')
+            return license_helpers.get_license_url(
+                obj.license, obj.license_version, obj.meta_data
+            )
+        elif hasattr(obj, 'license_url') and obj.license_url is not None:
+            log.info(f'found license url in obj {obj.license_url}')
+            return obj.license_url
+        else:
+            log.info('no metadata')
+            return license_helpers.get_license_url(
+                obj.license, obj.license_version, None
+            )
 
     def validate_url(self, value):
         return _add_protocol(value)

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -321,17 +321,13 @@ class ImageSerializer(serializers.Serializer):
         return obj.license.lower()
 
     def get_license_url(self, obj):
-        import logging as log
         if hasattr(obj, 'meta_data'):
-            log.info('found license in metadata')
             return license_helpers.get_license_url(
                 obj.license, obj.license_version, obj.meta_data
             )
         elif hasattr(obj, 'license_url') and obj.license_url is not None:
-            log.info(f'found license url in obj {obj.license_url}')
             return obj.license_url
         else:
-            log.info('no metadata')
             return license_helpers.get_license_url(
                 obj.license, obj.license_version, None
             )

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -100,7 +100,8 @@ class Image(SyncableDocType):
             likes=likes,
             categories=get_categories(extension, provider),
             aspect_ratio=Image.get_aspect_ratio(height, width),
-            size=Image.get_size(height, width)
+            size=Image.get_size(height, width),
+            license_url=Image.get_license_url(row[schema['meta_data']])
         )
 
     @staticmethod
@@ -144,6 +145,17 @@ class Image(SyncableDocType):
         for size in Image.ImageSizes:
             if resolution < size.value:
                 return size.name.lower()
+
+    @staticmethod
+    def get_license_url(meta_data):
+        """
+        If the license_url is not provided, we'll try to generate it elsewhere
+        from the `license` and `license_version`.
+        """
+        if 'license_url' in meta_data:
+            return meta_data['license_url']
+        else:
+            return None
 
     @staticmethod
     def parse_detailed_tags(json_tags):

--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -57,6 +57,15 @@ def create_mapping(table_name):
                         },
                         "type": "text"
                     },
+                    "license_url": {
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        },
+                        "type": "text"
+                    },
                     "tags": {
                         "properties": {
                             "accuracy": {

--- a/ingestion_server/ingestion_server/indexer_worker.py
+++ b/ingestion_server/ingestion_server/indexer_worker.py
@@ -32,6 +32,7 @@ class IndexingJobResource:
         target_index = j['target_index']
         notify_url = f'http://{req.remote_addr}:8001/worker_finished'
         _execute_indexing_task(target_index, start_id, end_id, notify_url)
+        log.info(f'Received indexing request for records {start_id}-{end_id}')
         resp.status = falcon.HTTP_201
 
 

--- a/ingestion_server/test/unit_tests.py
+++ b/ingestion_server/test/unit_tests.py
@@ -21,6 +21,11 @@ def create_mock_image(override=None):
         'likes': 3,
         'comments': 1
     }
+    license_url = 'https://creativecommons.org/licenses/by/2.0/fr/legalcode'
+    meta_data = {
+        'popularity_metrics': test_popularity,
+        'license_url': license_url
+    }
     test_data = {
         'id': 0,
         'title': 'Unit test title',
@@ -39,7 +44,7 @@ def create_mock_image(override=None):
         'view_count': 0,
         'height': 500,
         'width': 500,
-        'meta_data': {'popularity_metrics': test_popularity}
+        'meta_data': meta_data
     }
     for k, v in override.items():
         test_data[k] = v


### PR DESCRIPTION
Fixes https://github.com/creativecommons/cccatalog-api/issues/415

Our original model assumed that a CC license has the same terms across all languages. This is only true for versions 4.0 and higher. All other licenses have different terms in each jurisdiction, so we need to make sure that we provide a link to the correct license in those cases.

If we have the exact `license_url` for an image upstream (which might include the jurisdiction-specific URL), use it. Otherwise, we will try to generate the `license_url` from the `license` and `license_version` fields. 
