### PR TITLE
A small documentation error under image_search

### DIFF
--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -357,8 +357,8 @@ class ImageSearchResultsSerializer(serializers.Serializer):
 class InputErrorSerializer(serializers.Serializer):
     """ Returned if invalid query parameters are passed. """
     detail = serializers.CharField()
-    fields = serializers.ListField()
-    error = serializers.CharField()
+    field = serializers.ListField()
+    error_type = serializers.CharField()
 
 
 class WatermarkQueryStringSerializer(serializers.Serializer):


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #452 

<!-- Short description explaining the high-level reason for the pull request -->
The 400 Bad Request response for the images/ endpoint has keys: error_type, field and
detail. But in the documentation, it is mentioned that the keys are: error, fields and detail.
Compare and contrast the api response in https://api.creativecommons.engineering/v1/images?q=+ and the keys for 400 response type under https://api.creativecommons.engineering/v1/#operation/image_search
---

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

