### PR TITLE
Add 7 second search timeout to kill off unhealthy requests

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -325,7 +325,7 @@ def search(search_params, index, page_size, ip, request,
     s.extra(track_scores=True)
     # Route users to the same Elasticsearch worker node to reduce
     # pagination inconsistencies and increase cache hits.
-    s = s.params(preference=str(ip), request_timeout=5)
+    s = s.params(preference=str(ip), request_timeout=7)
     # Paginate
     start, end = _get_query_slice(s, page_size, page, filter_dead)
     s = s[start:end]

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -325,7 +325,7 @@ def search(search_params, index, page_size, ip, request,
     s.extra(track_scores=True)
     # Route users to the same Elasticsearch worker node to reduce
     # pagination inconsistencies and increase cache hits.
-    s = s.params(preference=str(ip))
+    s = s.params(preference=str(ip), request_timeout=5)
     # Paginate
     start, end = _get_query_slice(s, page_size, page, filter_dead)
     s = s[start:end]


### PR DESCRIPTION
Related to https://github.com/creativecommons/ccsearch-infrastructure/issues/119

We're having occasional issues with Elasticsearch getting stuck on a query in production. Since we are unable to set a global timeout due to limitations of AWS Elasticsearch Service, it seems reasonable to set a timeout on search queries instead.