### PR TITLE
Rewrite source filtering logic

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -247,7 +247,7 @@ def search(search_params, index, page_size, ip, request,
     to_exclude = []
     for filtered in filtered_providers:
         to_exclude.append(filtered['provider_identifier'])
-    s = s.exclude('term', provider=to_exclude)
+    s = s.exclude('terms', provider=to_exclude)
 
     # Search either by generic multimatch or by "advanced search" with
     # individual field-level queries specified.

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -244,8 +244,10 @@ def search(search_params, index, page_size, ip, request,
             timeout=CACHE_TIMEOUT,
             value=filtered_providers
         )
+    to_exclude = []
     for filtered in filtered_providers:
-        s = s.exclude('match', provider=filtered['provider_identifier'])
+        to_exclude.append(filtered['provider_identifier'])
+    s = s.exclude('term', provider=to_exclude)
 
     # Search either by generic multimatch or by "advanced search" with
     # individual field-level queries specified.

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -244,9 +244,7 @@ def search(search_params, index, page_size, ip, request,
             timeout=CACHE_TIMEOUT,
             value=filtered_providers
         )
-    to_exclude = []
-    for filtered in filtered_providers:
-        to_exclude.append(filtered['provider_identifier'])
+    to_exclude = [f['provider_identifier'] for f in filtered_providers]
     s = s.exclude('terms', provider=to_exclude)
 
     # Search either by generic multimatch or by "advanced search" with


### PR DESCRIPTION
I think this is the culprit behind Elasticsearch getting backed up and overloaded every once in a while.

After the usual Elasticsearch incident took place today on our brand-spanking-new EC2 cluster, I went into our new cluster's logs (not previously possible with the managed version...) and saw lots of slow queries that looked like this:

```
{"type": "server", "timestamp": "2020-04-30T23:13:39,433Z", "level": "DEBUG", "component": "o.e.a.s.TransportSearchAction", "cluster.name": "ccsearch-prod", "node.name": "172.30.1.113", "message": "[image-64585e2af24744819d29202556df7396][5], node[ON58EM7CQ6GN1uClGp5cxA], [R], s[STARTED], a[id=27Q4nL3nRsu2Uja23clnKw]: Failed to execute [SearchRequest{searchType=QUERY_THEN_FETCH, indices=[image], indicesOptions=IndicesOptions[ignore_unavailable=false, allow_no_indices=true, expand_wildcards_open=true, expand_wildcards_closed=false, allow_aliases_to_multiple_indices=true, forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true], types=[], routing='null', preference='-5579493936124596879', requestCache=null, scroll=null, maxConcurrentShardRequests=0, batchedReduceSize=512, preFilterShardSize=128, allowPartialSearchResults=true, localClusterAlias=null, getOrCreateAbsoluteStartMillis=-1, ccsMinimizeRoundtrips=true, source={\"from\":0,\"size\":20,\"query\":{\"bool\":{\"must\":[{\"simple_query_string\":{\"query\":\"<removed for privacy>\",\"fields\":[\"description^1.0\",\"title^1.0\",\"tags.name^1.0\"],\"flags\":-1,\"default_operator\":\"or\",\"analyze_wildcard\":false,\"auto_generate_synonyms_phrase_query\":true,\"fuzzy_prefix_length\":0,\"fuzzy_max_expansions\":50,\"fuzzy_transpositions\":true,\"boost\":1.0}}],\"filter\":[{\"bool\":{\"must_not\":[{\"term\":{\"mature\":{\"value\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"europeana\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"nhl\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"nypl\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"iha\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"500px\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"eol\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"sciencemuseum\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"smithsonian\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},{\"bool\":{\"must_not\":[{\"match\":{\"provider\":{\"query\":\"behance\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}}],\"adjust_pure_negative\":true,\"boost\":1.0}},\"highlight\":{\"order\":\"score\",\"fields\":{\"tags.name\":{},\"title\":{},\"description\":{}}},\"suggest\":{\"get_suggestion\":{\"text\":\"<removed for privacy>\",\"term\":{\"field\":\"creator\",\"suggest_mode\":\"MISSING\",\"accuracy\":0.5,\"sort\":\"SCORE\",\"string_distance\":\"INTERNAL\",\"max_edits\":2,\"max_inspections\":5,\"max_term_freq\":0.01,\"prefix_length\":1,\"min_word_length\":4,\"min_doc_freq\":0.0}}}}}] lastShard
[true]", "cluster.uuid": "OY661pxrSk-hPKq04guJWQ", "node.id": "ON58EM7CQ6GN1uClGp5cxA" ,
```
The queries for excluding filtered sources are way too complicated. This is the result of some complexity hidden by `elasticsearch_dsl`; calling `exclude` creates a brand new `must_not` query (and a bunch of other parameters) every single time. Instead, we need to call `exclude` once with all of the excluded sources in one argument.

It should also use `term` queries instead of `match`; `match` does some fuzzy analysis / stemming; we don't need to do that for a simple exclusion query. `terms` only looks for exact matches. This probably compounded the problem even further.

The result of these changes is that the query is much simpler. Here is the result with Flickr and Behance filtered on my local machine:
```
{'query': {'bool': {'filter': [{'bool': {'must_not': [{'term': {'mature': True}}]}}, {'bool': {'must_not': [{'terms': {'provider': ['flickr', 'behance']}}]}}], 'must': [{'simple_query_string': {'query': 'test', 'fields': ['tags.name', 'title', 'description']}}]}}, 'from': 0, 'size': 40, 'highlight': {'fields': {'tags.name': {}, 'title': {}, 'description': {}}, 'order': 'score'}, 'suggest': {'get_suggestion': {'text': 'test', 'term': {'field': 'creator'}}}}
```