### PR TITLE
Increase shard count

### DIFF
--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -9,7 +9,7 @@ def create_mapping(table_name):
         'image': {
             "settings": {
                 "index": {
-                    "number_of_shards": 12,
+                    "number_of_shards": 18,
                     "number_of_replicas": 0,
                     "refresh_interval": "-1"
                 }

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -332,7 +332,7 @@ class TableIndexer:
             es.cluster.health(
                 index=write_index,
                 wait_for_status='green',
-                timeout="2h"
+                timeout="3h"
             )
         # If the index exists already and it's not an alias, delete it.
         if live_alias in indices:

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -322,10 +322,10 @@ class TableIndexer:
                 }
             }
         )
-        # Cluster status will be yellow in development environments because
-        # there will only be one node available. In production, there are many
-        # nodes, and the index should not be promoted until all shards have
-        # been initialized.
+        # Cluster status will always be yellow in development environments
+        # because there will only be one node available. In production, there
+        # are many nodes, and the index should not be promoted until all
+        # shards have been initialized.
         environment = os.getenv('ENVIRONMENT', 'local')
         if environment != 'local':
             log.info('Waiting for replica shards. . .')


### PR DESCRIPTION
Related to https://github.com/creativecommons/ccsearch-infrastructure/issues/120

This increases the shard count of our cluster and the wait_for_status timeout.

## Shard increase
Shards are used to distribute data evenly between Elasticsearch nodes. They should be between 10-50gb each; we are getting too close to 50gb, and our dataset is growing. Increasing the count to 18 shards will reduce the data set to about 25gb per shard. See [How many shards should I have in my Elasticsearch cluster?](https://www.elastic.co/blog/how-many-shards-should-i-have-in-my-elasticsearch-cluster)

## wait_for_status timeout increase
During indexing, we create a temporary index in parallel with production to populate the refreshed documents. We disable shard replicas during index to reduce the CPU load of indexing. When shards are re-enabled, it takes time (currently around an hour) to reinitialize the index's replica shards (as this entails transferring 10s of gigs of data between every node). The bigger the dataset is, the longer it will take for replica shards to initialize; I want to make sure there is some extra slack in the timeout to accommodate the growth of our dataset. The index cannot be promoted to production until replica shard initialization has completed, or else performance may suffer and cause a cascading failure. If the timeout interval passes, the index will not be promoted.