### PR TITLE
Cache source count for 20 minutes instead of 10 seconds

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -17,7 +17,7 @@ from typing import Tuple, List, Optional
 from math import ceil
 
 ELASTICSEARCH_MAX_RESULT_WINDOW = 10000
-CACHE_TIMEOUT = 10
+CACHE_TIMEOUT = 60 * 20
 DEAD_LINK_RATIO = 1 / 2
 THUMBNAIL = 'thumbnail'
 URL = 'url'

--- a/cccatalog-api/cccatalog/wsgi.py
+++ b/cccatalog-api/cccatalog/wsgi.py
@@ -10,7 +10,6 @@ https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
-from django.core.cache import cache
 from wsgi_basic_auth import BasicAuth
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cccatalog.settings")
@@ -19,4 +18,3 @@ from gevent import monkey
 monkey.patch_all()
 application = get_wsgi_application()
 application = BasicAuth(application)
-cache.delete('providers-image')

--- a/cccatalog-api/cccatalog/wsgi.py
+++ b/cccatalog-api/cccatalog/wsgi.py
@@ -10,6 +10,7 @@ https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from django.core.cache import cache
 from wsgi_basic_auth import BasicAuth
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cccatalog.settings")
@@ -18,3 +19,4 @@ from gevent import monkey
 monkey.patch_all()
 application = get_wsgi_application()
 application = BasicAuth(application)
+cache.delete('providers-image')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
 
   cache:
     image: redis:4.0.10
-    container-name: cccatalog-api_cache_1
+    container_name: cccatalog-api_cache_1
     ports:
       - "6379:6379"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
 
   cache:
     image: redis:4.0.10
+    container-name: cccatalog-api_cache_1
     ports:
       - "6379:6379"
 

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -22,3 +22,5 @@ PGPASSWORD=deploy psql -U deploy -d openledger -h localhost -p 5433 -c "\copy im
 curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model": "image", "action": "LOAD_TEST_DATA"}'
 # Ingest and index the data
 curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model": "image", "action": "INGEST_UPSTREAM"}'
+# Clear source cache since it's out of date after data has been loaded
+docker exec -it cccatalog-api_cache_1 /bin/bash -c "echo \"del :1:providers-image\" | redis-cli"


### PR DESCRIPTION
`get_providers` is called on the "about" page in CC Search, which returns statistics about the number of images each source contributes to the catalog. Generating this query is expensive and needs to be cached for as long as possible, as it can block other queries from running.

Instead of caching it for 10 seconds, we should cache it on the order of minutes. This PR increases it to 20 minutes.

The longer cache period creates a race condition in the unit tests, so we have to manually unset it after test data has been loaded. In production conditions, it won't matter if the source cache is 20 minutes stale.