### PR TITLE
Thumbproxy productionization

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -129,7 +129,7 @@ def _post_process_results(s, start, end, page_size, search_results,
                 to_proxy = URL
             original = res[to_proxy]
             ext = res["url"].split(".")[-1]
-            proxied = "http://{}{}".format(
+            proxied = "https://{}{}".format(
                 request.get_host(),
                 reverse('thumbs', kwargs={
                     'identifier': "{}.{}".format(res["identifier"], ext)

--- a/cccatalog-api/cccatalog/api/utils/throttle.py
+++ b/cccatalog-api/cccatalog/api/utils/throttle.py
@@ -51,7 +51,7 @@ class TenPerDay(AnonRateThrottle):
 
 
 class OneThousandPerMinute(AnonRateThrottle):
-    rate = '1000/minute'
+    rate = '1000/min'
 
 
 class OnePerSecond(AnonRateThrottle):

--- a/cccatalog-api/cccatalog/api/utils/throttle.py
+++ b/cccatalog-api/cccatalog/api/utils/throttle.py
@@ -50,6 +50,10 @@ class TenPerDay(AnonRateThrottle):
     rate = '10/day'
 
 
+class OneThousandPerMinute(AnonRateThrottle):
+    rate = '1000/minute'
+
+
 class OnePerSecond(AnonRateThrottle):
     rate = '1/second'
 

--- a/cccatalog-api/cccatalog/api/views/site_views.py
+++ b/cccatalog-api/cccatalog/api/views/site_views.py
@@ -14,7 +14,8 @@ from cccatalog.api.serializers.oauth2_serializers import\
 from drf_yasg.utils import swagger_auto_schema
 from cccatalog.api.models import ContentProvider, Image
 from cccatalog.api.models import ThrottledApplication, OAuth2Verification
-from cccatalog.api.utils.throttle import TenPerDay, OnePerSecond, OneThousandPerMinute
+from cccatalog.api.utils.throttle import TenPerDay, OnePerSecond,\
+    OneThousandPerMinute
 from cccatalog.api.utils.oauth2_helper import get_token_info
 from cccatalog.settings import THUMBNAIL_PROXY_URL, THUMBNAIL_WIDTH_PX
 from django.core.cache import cache

--- a/cccatalog-api/cccatalog/api/views/site_views.py
+++ b/cccatalog-api/cccatalog/api/views/site_views.py
@@ -13,7 +13,7 @@ from cccatalog.api.serializers.oauth2_serializers import\
 from drf_yasg.utils import swagger_auto_schema
 from cccatalog.api.models import ContentProvider, Image
 from cccatalog.api.models import ThrottledApplication, OAuth2Verification
-from cccatalog.api.utils.throttle import TenPerDay, OnePerSecond
+from cccatalog.api.utils.throttle import TenPerDay, OnePerSecond, OneThousandPerMinute
 from cccatalog.api.utils.oauth2_helper import get_token_info
 from cccatalog.settings import THUMBNAIL_PROXY_URL, THUMBNAIL_WIDTH_PX
 from django.core.cache import cache
@@ -297,6 +297,7 @@ class Thumbs(APIView):
 
     lookup_field = 'identifier'
     queryset = Image.objects.all()
+    throttle_classes = [OneThousandPerMinute]
 
     @swagger_auto_schema(operation_id="thumb_lookup",
                          responses={

--- a/cccatalog-api/cccatalog/api/views/site_views.py
+++ b/cccatalog-api/cccatalog/api/views/site_views.py
@@ -1,6 +1,7 @@
 import logging as log
 import secrets
 import smtplib
+from urllib.error import HTTPError
 from urllib.request import urlopen
 from django.core.mail import send_mail
 from rest_framework.response import Response
@@ -325,9 +326,12 @@ class Thumbs(APIView):
             width=THUMBNAIL_WIDTH_PX,
             original=image.url
         )
-        upstream_response = urlopen(upstream_url)
-        status = upstream_response.status
-        content_type = upstream_response.headers.get('Content-Type')
+        try:
+            upstream_response = urlopen(upstream_url)
+            status = upstream_response.status
+            content_type = upstream_response.headers.get('Content-Type')
+        except HTTPError:
+            return HttpResponse(status=500)
 
         response = HttpResponse(
             upstream_response.read(),


### PR DESCRIPTION
## Related to https://github.com/creativecommons/cccatalog-api/issues/444, https://github.com/creativecommons/cccatalog-api/pull/460

## Description
This makes a few adjustments to a community PR to make it more suitable for production conditions.

- Requests towards the thumbnail proxy should not be assigned the default throttle class, or else it will count towards the user's overall rate limit (which will result in 429 errors being thrown for no reason).
- Requests to the thumbnail proxy must be SSL secured in order to show up on the front end.
- If the thumbnail proxy is unreachable or otherwise cannot handle an image, we should explicitly return an internal server error.