### PR TITLE
Optimize /v1/sources

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -452,7 +452,7 @@ def get_providers(index):
         # Invalidate old provider format.
         cache.delete(key=provider_cache_name)
     if not providers:
-        elasticsearch_maxint = 2147483647
+        elasticsearch_maxint = 100
         agg_body = {
             'aggs': {
                 'unique_providers': {

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -466,18 +466,18 @@ def get_providers(index):
                 }
             }
         }
-        s = Search.from_dict(agg_body)
-        s = s.index(index)
         try:
-            results = s.execute().aggregations['unique_providers']['buckets']
+            results = es.search(index=index, body=agg_body, request_cache=True)
+            buckets = results['aggregations']['unique_providers']['buckets']
         except NotFoundError:
-            results = [{'key': 'none_found', 'doc_count': 0}]
-        providers = {result['key']: result['doc_count'] for result in results}
+            buckets = [{'key': 'none_found', 'doc_count': 0}]
+        providers = {result['key']: result['doc_count'] for result in buckets}
         cache.set(
             key=provider_cache_name,
             timeout=CACHE_TIMEOUT,
             value=providers
         )
+
     return providers
 
 

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -479,7 +479,6 @@ def get_providers(index):
             timeout=CACHE_TIMEOUT,
             value=providers
         )
-
     return providers
 
 

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -452,13 +452,15 @@ def get_providers(index):
         # Invalidate old provider format.
         cache.delete(key=provider_cache_name)
     if not providers:
-        elasticsearch_maxint = 100
+        # Don't increase `size` without reading this issue first:
+        # https://github.com/elastic/elasticsearch/issues/18838
+        size = 100
         agg_body = {
             'aggs': {
                 'unique_providers': {
                     'terms': {
                         'field': 'provider.keyword',
-                                 'size': elasticsearch_maxint,
+                        'size': size,
                         "order": {
                             "_key": "desc"
                         }


### PR DESCRIPTION
# Related to https://github.com/creativecommons/ccsearch-infrastructure/issues/120

The [/v1/sources](https://api.creativecommons.engineering/v1/sources) endpoint is expensive and used heavily by clients. It needs to count every single image in our catalog in milliseconds. The expense of this endpoint is causing problems in our new Elasticsearch cluster architecture, which trades off CPU cores (important for this query specifically, but unimportant for searches) for storage IO performance (critical for searches). The cluster can hang for several seconds while this value is computed, which can result in searches timing out.

To cope with this, we cache the value server-side for a long period of time (20 minutes). The problem is that when this cache expires, there can be a [thundering herd](https://en.wikipedia.org/wiki/Thundering_herd_problem) effect as every one of our many API server instances asks Elasticsearch to compute this aggregation. To prevent this from sucking up the entire cluster's capacity, we need to tell Elasticsearch to cache the aggregation internally, which it doesn't do by default for whatever reason. Preliminary testing indicates this reduces the computation period to 500ms, which is short enough not to impact other searches substantially. Without `request_cache=True`, this endpoint takes up to 6 seconds, which is then multiplied by the number of servers making the request simultaneously (up to 7), leading to CC Search being temporarily unresponsive.

This PR also limits the `size` parameter to 100, which translates to "show me the the top 100 sources in our collection". We have about 30 right now, so this change has no direct impact on the results of `/v1/sources`, but does have performance implications for Elasticsearch (more details [here](https://github.com/elastic/elasticsearch/issues/18838)). If we reach a point where there are hundreds/thousands of sources, we are going to need to re-engineer this endpoint so the result is built statically during indexing rather than dynamically by Elasticsearch.