### PR TITLE
Don't wait for replica shards.

### DIFF
--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -322,18 +322,6 @@ class TableIndexer:
                 }
             }
         )
-        # Cluster status will always be yellow in development environments
-        # because there will only be one node available. In production, there
-        # are many nodes, and the index should not be promoted until all
-        # shards have been initialized.
-        environment = os.getenv('ENVIRONMENT', 'local')
-        if environment != 'local':
-            log.info('Waiting for replica shards. . .')
-            es.cluster.health(
-                index=write_index,
-                wait_for_status='green',
-                timeout="3h"
-            )
         # If the index exists already and it's not an alias, delete it.
         if live_alias in indices:
             log.warning('Live index already exists. Deleting and realiasing.')


### PR DESCRIPTION
## Fixes https://github.com/creativecommons/cccatalog-api/issues/495

## Description
Instead of waiting for replica shards to initialize, we will direct searches to the new search index right after data has been successfully loaded.

Please see the tagged issue for a more detailed background on why this change is necessary and what prompted it.