### PR TITLE
Retry unsuccessful bulk uploads.

### DIFF
--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -283,7 +283,6 @@ class TableIndexer:
                     self._bulk_upload(es_batch)
                 except ValueError:
                     log.error('Failed to index chunk.')
-                    pass
                 upload_time = time.time() - push_start_time
                 upload_rate = len(es_batch) / upload_time
                 log.info(

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -226,8 +226,8 @@ class TableIndexer:
             except elasticsearch.ElasticsearchException:
                 # Something went wrong during indexing.
                 log.warning(
-                    "Elasticsearch rejected bulk query. We will retry in a"
-                    " moment. Details: ",
+                    f"Elasticsearch rejected bulk query. We will retry in"
+                    f" {cooloff}s. Attempt {attempts}. Details: ",
                     exc_info=True
                 )
                 time.sleep(cooloff)


### PR DESCRIPTION
## Description
During bulk indexing, Elasticsearch can become overwhelmed with writes and reject indexing requests. There could also be rare cases where the upstream data is malformed in a way that prevents the indexer from uploading a particular chunk of data. Either case causes the indexer worker to stop indexing its batch.

If a bulk indexing request is rejected for any reason, we will retry with exponential backoff. If `max_attempts` is exceeded, this batch will be skipped and we will continue indexing the rest of the data.

Once we have some more detailed logs, we will be able to implement better handling of malformed rows and discard them from the upload batch.