### PR TITLE
Adjust Elasticsearch retries and timeouts

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -500,8 +500,8 @@ def _elasticsearch_connect():
         host=settings.ELASTICSEARCH_URL,
         port=settings.ELASTICSEARCH_PORT,
         connection_class=RequestsHttpConnection,
-        timeout=10,
-        max_retries=99,
+        timeout=5,
+        max_retries=2,
         retry_on_timeout=True,
         http_auth=auth,
         wait_for_status='yellow'

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -500,8 +500,8 @@ def _elasticsearch_connect():
         host=settings.ELASTICSEARCH_URL,
         port=settings.ELASTICSEARCH_PORT,
         connection_class=RequestsHttpConnection,
-        timeout=5,
-        max_retries=2,
+        timeout=10,
+        max_retries=1,
         retry_on_timeout=True,
         http_auth=auth,
         wait_for_status='yellow'

--- a/ingestion_server/ingestion_server/distributed_reindex_scheduler.py
+++ b/ingestion_server/ingestion_server/distributed_reindex_scheduler.py
@@ -53,7 +53,7 @@ def _assign_work(db_conn, workers, target_index):
             'end_id': (1 + idx) * records_per_worker,
             'target_index': target_index
         }
-        log.info(f'Assigned job: {params}')
+        log.info(f'Assigning job {params} to {worker_url}')
         requests.post(worker_url + '/indexing_task', json=params)
 
 

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -104,8 +104,6 @@ def _elasticsearch_connect():
         host=ELASTICSEARCH_URL,
         port=ELASTICSEARCH_PORT,
         connection_class=RequestsHttpConnection,
-        max_retries=10,
-        retry_on_timeout=True,
         http_auth=auth,
         wait_for_status='yellow'
     )

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -70,7 +70,7 @@ def elasticsearch_connect(timeout=300):
     """
     while True:
         try:
-            return _elasticsearch_connect(timeout)
+            return _elasticsearch_connect()
         except ElasticsearchConnectionError as e:
             log.exception(e)
             log.error('Reconnecting to Elasticsearch in 5 seconds. . .')
@@ -78,7 +78,7 @@ def elasticsearch_connect(timeout=300):
             continue
 
 
-def _elasticsearch_connect(timeout=300):
+def _elasticsearch_connect():
     """
     Connect to configured Elasticsearch domain.
 
@@ -104,7 +104,6 @@ def _elasticsearch_connect(timeout=300):
         host=ELASTICSEARCH_URL,
         port=ELASTICSEARCH_PORT,
         connection_class=RequestsHttpConnection,
-        timeout=timeout,
         max_retries=10,
         retry_on_timeout=True,
         http_auth=auth,


### PR DESCRIPTION
## Description
Early on in this project, I set `max_retries` and `timeout` in the ES constructor to large values thinking that they controlled only connection retries/timeouts. In reality, it applies to all calls made in the client. This caused the problems described here: https://github.com/creativecommons/cccatalog-api/pull/496 .

We need to not retry Elasticsearch queries so aggressively. 10 seconds is a pretty long time, so one retry should be sufficient. In the context of indexing, we don't want to leave retries to the client at all.

This PR fixes those timeouts and restores the `wait_for_status` check.