### PR TITLE
Restore wait_for_status check

### DIFF
--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -347,6 +347,18 @@ class TableIndexer:
                 }
             }
         )
+        # Cluster status will always be yellow in development environments
+        # because there will only be one node available. In production, there
+        # are many nodes, and the index should not be promoted until all
+        # shards have been initialized.
+        environment = os.getenv('ENVIRONMENT', 'local')
+        if environment != 'local':
+            log.info('Waiting for replica shards. . .')
+            es.cluster.health(
+                index=write_index,
+                wait_for_status='green',
+                timeout="3h"
+            )
         # If the index exists already and it's not an alias, delete it.
         if live_alias in indices:
             log.warning('Live index already exists. Deleting and realiasing.')


### PR DESCRIPTION
## Description
See https://github.com/creativecommons/cccatalog-api/pull/498; now that we aren't timing out after five minutes, we can wait for replica shards to be reinitialized (which takes about an hour with our current workload).