### PR TITLE
Exclude deindexed images from the ingestion process

### DIFF
--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -247,7 +247,10 @@ def reload_upstream(table, progress=None, finish_time=None):
         CREATE TABLE temp_import_{table} (LIKE {table} INCLUDING CONSTRAINTS);
         CREATE TEMP SEQUENCE IF NOT EXISTS image_id_temp_seq;
         INSERT INTO temp_import_{table} ({cols})
-        SELECT {insert_cols} from upstream_schema.{table};
+        SELECT {insert_cols} from upstream_schema.{table} img
+          WHERE NOT EXISTS(
+            SELECT FROM api_deletedimage WHERE identifier = img.identifier
+          );
         ALTER TABLE temp_import_{table} ADD PRIMARY KEY (id);
         DROP SERVER upstream CASCADE;
     '''.format(table=table, cols=query_cols, insert_cols=query_cols_nextval)


### PR DESCRIPTION
## Fixes https://github.com/creativecommons/cccatalog-api/issues/508

## Description
Images that we choose to deindex (such as for a DMCA takedown or other legal matter) can be added back to our database by the weekly ingestion job. The result is that, although the image will not appear in our search results, someone with the direct URL to the image can view the "deindexed" work after the ingestion process runs.

To fix this, we need to exclude images in the `api_deletedimages` table (populated by our reporting interface) from the ingestion process.

## Tests
I verified this feature manually by taking the following steps:

1. Start the server with docker-compose.
2. Set up a Django superuser and go to the /admin page.
3. Delete an image through the Report Images UI.
4. Reingest the data with `curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model": "image", "action": "INGEST_UPSTREAM"}'`
5. Verified that the image is not accessible after reingestion.