### PR TITLE
Remove extension parsing logic

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -122,9 +122,7 @@ def _post_process_results(s, start, end, page_size, search_results,
             # Route all images through a dynamically resizing caching proxy.
             proxied = "https://{}{}".format(
                 request.get_host(),
-                reverse('thumbs', kwargs={
-                    'identifier': "{}".format(res["identifier"])
-                })
+                reverse('thumbs', kwargs={'identifier': res["identifier"]})
             )
             res[THUMBNAIL] = proxied
         results.append(res)

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -120,19 +120,10 @@ def _post_process_results(s, start, end, page_size, search_results,
         to_validate.append(res.url)
         if PROXY_THUMBS:
             # Route all images through a dynamically resizing caching proxy.
-            # If a 3rd party thumbnail is available, in order to save limited
-            # bandwidth and memory resources required for resizing, we'll
-            # proxy the 3rd party thumbnail instead of the full-sized image.
-            if THUMBNAIL in res:
-                to_proxy = THUMBNAIL
-            else:
-                to_proxy = URL
-            original = res[to_proxy]
-            ext = res["url"].split(".")[-1]
             proxied = "https://{}{}".format(
                 request.get_host(),
                 reverse('thumbs', kwargs={
-                    'identifier': "{}.{}".format(res["identifier"], ext)
+                    'identifier': "{}".format(res["identifier"])
                 })
             )
             res[THUMBNAIL] = proxied

--- a/cccatalog-api/cccatalog/api/views/site_views.py
+++ b/cccatalog-api/cccatalog/api/views/site_views.py
@@ -308,27 +308,18 @@ class Thumbs(APIView):
                              404: 'Not Found'
                          })
     def get(self, request, identifier, format=None):
-        path_element = identifier.split(".")
-        identifier = path_element[0]
-        extname = ""
-        if len(path_element) == 2:
-            extname = path_element[1]
-        elif len(path_element) > 2:
-            return Response(status=400)
         try:
             image = Image.objects.get(identifier=identifier)
-            if extname and image.url.split(".")[-1] != extname:
-                return Response(status=404, data='Not Found')
         except Image.DoesNotExist:
             return Response(status=404, data='Not Found')
 
-        upstream_url = '{proxy_url}/{width}/{original}'.format(
+        proxy_upstream = '{proxy_url}/{width}/{original}'.format(
             proxy_url=THUMBNAIL_PROXY_URL,
             width=THUMBNAIL_WIDTH_PX,
             original=image.url
         )
         try:
-            upstream_response = urlopen(upstream_url)
+            upstream_response = urlopen(proxy_upstream)
             status = upstream_response.status
             content_type = upstream_response.headers.get('Content-Type')
         except HTTPError:


### PR DESCRIPTION
## Fixes #509, #510 
## Description
This PR removes file extensions from thumbnail URLs. This was causing problems rendering views containing images without a file extension in their upstream URL. There is no need to specify the file extension for thumbnail URLs since browsers determine the format of images by the `Content-Type` header.