### PR TITLE
Add handling for malformed tags in cleanup process

### DIFF
--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -101,8 +101,14 @@ class CleanupFunctions:
             below_threshold = False
             if 'accuracy' in tag and tag['accuracy'] < TAG_MIN_CONFIDENCE:
                 below_threshold = True
-            lower_tag = tag['name'].lower()
-            should_filter = _tag_blacklisted(lower_tag) or below_threshold
+
+            if 'name' in tag:
+                lower_tag = tag['name'].lower()
+                should_filter = _tag_blacklisted(lower_tag) or below_threshold
+            else:
+                log.error(f'Filtering malformed tag "{tag}" in array "{tags}"')
+                should_filter = True
+
             if should_filter:
                 update_required = True
             else:

--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -101,14 +101,12 @@ class CleanupFunctions:
             below_threshold = False
             if 'accuracy' in tag and tag['accuracy'] < TAG_MIN_CONFIDENCE:
                 below_threshold = True
-
             if 'name' in tag:
                 lower_tag = tag['name'].lower()
                 should_filter = _tag_blacklisted(lower_tag) or below_threshold
             else:
-                log.error(f'Filtering malformed tag "{tag}" in array "{tags}"')
+                log.warning(f'Filtering malformed tag "{tag}" in array "{tags}"')
                 should_filter = True
-
             if should_filter:
                 update_required = True
             else:


### PR DESCRIPTION
## Fixes https://github.com/creativecommons/cccatalog-api/issues/520

## Technical details
This change filters out malformed tags during the cleanup process. If the `name` field is missing, the tag will be removed during the cleanup process.