### PR TITLE
Moved default value of django secret key to docker compose

### DIFF
--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -22,9 +22,7 @@ STATIC_ROOT = "/var/api_static_content/static"
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get(
-    'DJANGO_SECRET_KEY', 'ny#b__$f6ry4wy8oxre97&-68u_0lk3gw(z=d40_dxey3zw0v1'
-)
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 true_strings = ['true', 'True', 't']

--- a/cccatalog-api/test/run_test.sh
+++ b/cccatalog-api/test/run_test.sh
@@ -2,4 +2,4 @@
 # Local environments don't have valid certificates; suppress this warning.
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 export INTEGRATION_TEST_URL="http://localhost:8000"
-PYTHONPATH=. DJANGO_DATABASE_NAME='openledger' DJANGO_DATABASE_USER='deploy' DJANGO_DATABASE_PASSWORD='deploy' DJANGO_DATABASE_HOST='localhost' REDIS_HOST='localhost' pytest -s --disable-pytest-warnings test/v1_integration_test.py --ds=cccatalog.settings
+PYTHONPATH=. DJANGO_SECRET_KEY='ny#b__$f6ry4wy8oxre97&-68u_0lk3gw(z=d40_dxey3zw0v1' DJANGO_DATABASE_NAME='openledger' DJANGO_DATABASE_USER='deploy' DJANGO_DATABASE_PASSWORD='deploy' DJANGO_DATABASE_HOST='localhost' REDIS_HOST='localhost' pytest -s --disable-pytest-warnings test/v1_integration_test.py --ds=cccatalog.settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       DISABLE_GLOBAL_THROTTLING: "True"
       ROOT_SHORTENING_URL: "localhost:8000"
       THUMBNAIL_PROXY_URL: "http://thumbs:8222"
+      DJANGO_SECRET_KEY: "ny#b__$f6ry4wy8oxre97&-68u_0lk3gw(z=d40_dxey3zw0v1"
     stdin_open: true
     tty: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       DISABLE_GLOBAL_THROTTLING: "True"
       ROOT_SHORTENING_URL: "localhost:8000"
       THUMBNAIL_PROXY_URL: "http://thumbs:8222"
-      DJANGO_SECRET_KEY: "ny#b__$f6ry4wy8oxre97&-68u_0lk3gw(z=d40_dxey3zw0v1"
+      DJANGO_SECRET_KEY: 'ny#b__$$f6ry4wy8oxre97&-68u_0lk3gw(z=d40_dxey3zw0v1'
     stdin_open: true
     tty: true
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #519 by @TimidRobot 

## Description
Moves the default value of `SECRET_KEY` to `docker-compose.yml`

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
