### PR TITLE
Ignore license_version = null overrides

### DIFF
--- a/cccatalog-api/cccatalog/api/licenses.py
+++ b/cccatalog-api/cccatalog/api/licenses.py
@@ -27,9 +27,10 @@ ATTRIBUTION = \
 
 
 def get_license_url(_license, version, meta_data=None):
-    if meta_data and 'license_url' in meta_data:
+    license_overridden = meta_data and 'license_url' in meta_data
+    if license_overridden and meta_data['license_url'] is not None:
         return meta_data['license_url']
-    if _license.lower() == 'pdm':
+    elif _license.lower() == 'pdm':
         return 'https://creativecommons.org/publicdomain/mark/1.0/'
     else:
         return f'https://creativecommons.org/licenses/{_license}/{version}/'

--- a/cccatalog-api/test/v1_integration_test.py
+++ b/cccatalog-api/test/v1_integration_test.py
@@ -397,6 +397,16 @@ def test_attribution():
     assert title in all_data_present.attribution
     assert creator in all_data_present.attribution
 
+def test_license_override():
+    null_license_url = Image(
+        identifier="ab80dbe1-414c-4ee8-9543-f9599312aeb8",
+        title="test",
+        creator="test",
+        license="by",
+        license_version="3.0",
+        meta_data={'license_url': 'null'}
+    )
+    assert null_license_url.license_url is not None
 
 def test_source_search():
     response = requests.get(API_URL + '/v1/images?source=behance',


### PR DESCRIPTION
## Fixes https://github.com/creativecommons/cccatalog-api/issues/525

## Description
We can override `license_url` in `cccatalog` by setting a direct URL in the `meta_data` column. If it is set to `null`, the API server faithfully serves it up. Instead, we should fall back to the generated license URL.