### PR TITLE
Upstream schema fix

### DIFF
--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -242,7 +242,10 @@ def reload_upstream(table, progress=None, finish_time=None):
     copy_data = '''
         DROP TABLE IF EXISTS temp_import_{table};
         CREATE TABLE temp_import_{table} (LIKE {table} INCLUDING CONSTRAINTS);
+        CREATE TEMP SEQUENCE IF NOT EXISTS image_id_temp_seq;
         ALTER TABLE temp_import_{table} ADD COLUMN IF NOT EXISTS id serial;
+        ALTER TABLE temp_import_{table} ALTER COLUMN id
+          SET DEFAULT nextval('image_id_temp_seq'::regclass);
         INSERT INTO temp_import_{table} ({cols})
         SELECT {cols} from upstream_schema.{table} img
           WHERE NOT EXISTS(

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -215,9 +215,6 @@ def reload_upstream(table, progress=None, finish_time=None):
     )
     cols = _get_shared_cols(downstream_db, upstream_db, table)
     query_cols = ','.join(cols)
-    id_idx = cols.index('id')
-    cols[id_idx] = "nextval('image_id_temp_seq'::regclass)"
-    query_cols_nextval = ','.join(cols)
     upstream_db.close()
     # Connect to upstream database and create references to foreign tables.
     log.info('(Re)initializing foreign data wrapper')
@@ -245,15 +242,15 @@ def reload_upstream(table, progress=None, finish_time=None):
     copy_data = '''
         DROP TABLE IF EXISTS temp_import_{table};
         CREATE TABLE temp_import_{table} (LIKE {table} INCLUDING CONSTRAINTS);
-        CREATE TEMP SEQUENCE IF NOT EXISTS image_id_temp_seq;
+        ALTER TABLE temp_import_{table} ADD COLUMN IF NOT EXISTS id serial;
         INSERT INTO temp_import_{table} ({cols})
-        SELECT {insert_cols} from upstream_schema.{table} img
+        SELECT {cols} from upstream_schema.{table} img
           WHERE NOT EXISTS(
             SELECT FROM api_deletedimage WHERE identifier = img.identifier
           );
         ALTER TABLE temp_import_{table} ADD PRIMARY KEY (id);
         DROP SERVER upstream CASCADE;
-    '''.format(table=table, cols=query_cols, insert_cols=query_cols_nextval)
+    '''.format(table=table, cols=query_cols)
     create_indices = ';\n'.join(_generate_indices(downstream_db, table))
     remap_constraints = ';\n'.join(_generate_constraints(downstream_db, table))
     go_live = '''

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -246,6 +246,8 @@ def reload_upstream(table, progress=None, finish_time=None):
         ALTER TABLE temp_import_{table} ADD COLUMN IF NOT EXISTS id serial;
         ALTER TABLE temp_import_{table} ALTER COLUMN id
           SET DEFAULT nextval('image_id_temp_seq'::regclass);
+        ALTER TABLE temp_import_{table} ALTER COLUMN view_count
+          SET DEFAULT 0;
         INSERT INTO temp_import_{table} ({cols})
         SELECT {cols} from upstream_schema.{table} img
           WHERE NOT EXISTS(


### PR DESCRIPTION
## Related to https://github.com/creativecommons/cccatalog/pull/429
This change removes an unnecessary dependency on an upstream column that has been removed from the cccatalog schema. There's a workaround for the removed view_count column also, which will be removed from the API later in https://github.com/creativecommons/cccatalog-api/issues/540.

A sequential ID column is required for the indexer process to partition records between indexing workers. Instead of using the ID column from the catalog, it will create a column in the temporary ingestion table.