### PR TITLE
Fix broken HTTP images on detail pages

### DIFF
--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -15,7 +15,7 @@ from cccatalog.api.serializers.image_serializers import\
     InputErrorSerializer, ImageSearchQueryStringSerializer,\
     WatermarkQueryStringSerializer, ReportImageSerializer,\
     OembedSerializer
-from cccatalog.settings import THUMBNAIL_PROXY_URL
+from cccatalog.settings import DETAIL_PROXY_URL
 from cccatalog.api.utils.view_count import _get_user_ip
 from cccatalog.api.utils.watermark import watermark
 from django.http.response import HttpResponse, FileResponse
@@ -152,6 +152,14 @@ class ImageDetail(GenericAPIView, RetrieveModelMixin):
     def get(self, request, identifier, format=None, view_count=0):
         """ Get the details of a single list. """
         resp = self.retrieve(request, identifier)
+        # Proxy insecure HTTP images at full resolution.
+        if 'http://' in resp.data[search_controller.URL]:
+            original = resp.data[search_controller.URL]
+            secure = '{proxy_url}/{original}'.format(
+                proxy_url=DETAIL_PROXY_URL,
+                original=original
+            )
+            resp.data[search_controller.URL] = secure
 
         return resp
 

--- a/cccatalog-api/cccatalog/api/views/image_views.py
+++ b/cccatalog-api/cccatalog/api/views/image_views.py
@@ -152,15 +152,6 @@ class ImageDetail(GenericAPIView, RetrieveModelMixin):
     def get(self, request, identifier, format=None, view_count=0):
         """ Get the details of a single list. """
         resp = self.retrieve(request, identifier)
-        # Fix links to creator and foreign landing URLs.
-        # Proxy insecure HTTP images at full resolution.
-        if 'http://' in resp.data[search_controller.URL]:
-            original = resp.data[search_controller.URL]
-            secure = '{proxy_url}/{original}'.format(
-                proxy_url=THUMBNAIL_PROXY_URL,
-                original=original
-            )
-            resp.data[search_controller.URL] = secure
 
         return resp
 

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -159,6 +159,10 @@ PROXY_THUMBS = bool(os.environ.get('PROXY_THUMBS', True))
 THUMBNAIL_PROXY_URL = os.environ.get(
     'THUMBNAIL_PROXY_URL', 'http://localhost:8222'
 )
+# Proxy insecure HTTP images through our internal proxy.
+DETAIL_PROXY_URL = os.environ.get(
+    'DETAIL_PROXY_URL', 'https://api.creativecommons.engineering/t'
+)
 
 THUMBNAIL_WIDTH_PX = 600
 


### PR DESCRIPTION
We proxy insecure HTTP images through our internal proxy to make sure everything is SSL protected. Changing to internal thumbnailing broke this functionality; it would result in the `url` including a reference to `localhost`.