### PR TITLE
Use source field instead of provider

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -385,7 +385,7 @@ def get_sources(index):
     :param index: An Elasticsearch index, such as `'image'`.
     :return: A dictionary mapping sources to the count of their images.`
     """
-    source_cache_name = 'source-' + index
+    source_cache_name = 'sources-' + index
     sources = cache.get(key=source_cache_name)
     if type(sources) == list:
         # Invalidate old provider format.

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -209,7 +209,7 @@ def search(search_params, index, page_size, ip, request,
         ('categories', None),
         ('aspect_ratio', None),
         ('size', None),
-        ('source', 'provider'),
+        ('source', None),
         ('license', 'license__keyword'),
         ('license_type', 'license__keyword')
     ]
@@ -320,7 +320,7 @@ def search(search_params, index, page_size, ip, request,
 
 
 def _validate_provider(input_provider):
-    allowed_providers = list(get_providers('image').keys())
+    allowed_providers = list(get_sources('image').keys())
     lowercase_providers = [x.lower() for x in allowed_providers]
     if input_provider.lower() not in lowercase_providers:
         raise serializers.ValidationError(
@@ -378,27 +378,24 @@ def related_images(uuid, index, request, filter_dead):
     return results, result_count
 
 
-def get_providers(index):
+def get_sources(index):
     """
     Given an index, find all available data providers and return their counts.
 
     :param index: An Elasticsearch index, such as `'image'`.
     :return: A dictionary mapping providers to the count of their images.`
     """
-    provider_cache_name = 'providers-' + index
+    provider_cache_name = 'source-' + index
     providers = cache.get(key=provider_cache_name)
-    if type(providers) == list:
-        # Invalidate old provider format.
-        cache.delete(key=provider_cache_name)
     if not providers:
         # Don't increase `size` without reading this issue first:
         # https://github.com/elastic/elasticsearch/issues/18838
         size = 100
         agg_body = {
             'aggs': {
-                'unique_providers': {
+                'unique_sources': {
                     'terms': {
-                        'field': 'provider.keyword',
+                        'field': 'source.keyword',
                         'size': size,
                         "order": {
                             "_key": "desc"
@@ -409,7 +406,7 @@ def get_providers(index):
         }
         try:
             results = es.search(index=index, body=agg_body, request_cache=True)
-            buckets = results['aggregations']['unique_providers']['buckets']
+            buckets = results['aggregations']['unique_sources']['buckets']
         except NotFoundError:
             buckets = [{'key': 'none_found', 'doc_count': 0}]
         providers = {result['key']: result['doc_count'] for result in buckets}

--- a/cccatalog-api/cccatalog/api/models.py
+++ b/cccatalog-api/cccatalog/api/models.py
@@ -1,12 +1,10 @@
 from uuslug import uuslug
 from django.db import models
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from django.contrib.postgres.fields import JSONField, ArrayField
 from cccatalog.api.licenses import ATTRIBUTION, get_license_url
 from oauth2_provider.models import AbstractApplication
 import cccatalog.api.controllers.search_controller as search_controller
-import enum
 
 
 class OpenLedgerModel(models.Model):
@@ -193,7 +191,6 @@ class ImageList(OpenLedgerModel):
 class Tag(OpenLedgerModel):
     foreign_identifier = models.CharField(max_length=255, blank=True, null=True)
     name = models.CharField(max_length=1000, blank=True, null=True)
-    # Source can be a provider/source (like 'openimages', or 'user')
     source = models.CharField(max_length=255, blank=True, null=True)
     slug = models.SlugField(blank=True, null=True, max_length=255)
 

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from cccatalog.api.licenses import LICENSE_GROUPS, get_license_url
 from urllib.parse import urlparse
 from collections import namedtuple
-from cccatalog.api.controllers.search_controller import get_providers
+from cccatalog.api.controllers.search_controller import get_sources
 from cccatalog.api.models import ImageReport
 
 
@@ -124,7 +124,7 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
         label="provider",
         help_text="A comma separated list of data sources to search. Valid "
                   "inputs:"
-                  " `{}`".format(list(get_providers('image').keys())),
+                  " `{}`".format(list(get_sources('image').keys())),
         required=False
     )
     extension = serializers.CharField(
@@ -206,7 +206,7 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
 
     @staticmethod
     def validate_source(input_providers):
-        allowed_providers = list(get_providers('image').keys())
+        allowed_providers = list(get_sources('image').keys())
 
         for input_provider in input_providers.split(','):
             if input_provider not in allowed_providers:

--- a/cccatalog-api/cccatalog/api/views/site_views.py
+++ b/cccatalog-api/cccatalog/api/views/site_views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.views import APIView
 from rest_framework import serializers
-from cccatalog.api.controllers.search_controller import get_providers
+from cccatalog.api.controllers.search_controller import get_sources
 from cccatalog.api.serializers.oauth2_serializers import\
     OAuth2RegistrationSerializer, OAuth2RegistrationSuccessful, OAuth2KeyInfo
 from drf_yasg.utils import swagger_auto_schema
@@ -66,23 +66,23 @@ class ImageStats(APIView):
             rec[IDENTIFIER]:
                 (rec[NAME], rec[FILTER], rec[URL]) for rec in provider_data
         }
-        providers = get_providers('image')
+        sources = get_sources('image')
         response = []
-        for provider in providers:
-            if provider in provider_table:
-                display_name, _filter, provider_url = provider_table[provider]
+        for source in sources:
+            if source in provider_table:
+                display_name, _filter, provider_url = provider_table[source]
                 if not _filter:
                     response.append(
                         {
-                            'source_name': provider,
-                            'image_count': providers[provider],
+                            'source_name': source,
+                            'image_count': sources[source],
                             'display_name': display_name,
                             'source_url': provider_url
                         }
                     )
             else:
                 msg = 'provider_identifier missing from content_provider' \
-                      ' table: {}. Check for typos/omissions.'.format(provider)
+                      ' table: {}. Check for typos/omissions.'.format(source)
                 log.error(msg)
         return Response(status=200, data=response)
 

--- a/ingestion_server/ingestion_server/authority.py
+++ b/ingestion_server/ingestion_server/authority.py
@@ -55,19 +55,19 @@ authority_types = {
 }
 
 
-def get_authority_boost(provider):
+def get_authority_boost(source):
     authority_boost = None
-    if provider in authority_types:
-        authority_type = authority_types[provider]
+    if source in authority_types:
+        authority_type = authority_types[source]
         if authority_type in boost:
             authority_boost = boost[authority_type]
     return authority_boost
 
 
-def get_authority_penalty(provider):
+def get_authority_penalty(source):
     authority_penalty = None
-    if provider in authority_types:
-        authority_type = authority_types[provider]
+    if source in authority_types:
+        authority_type = authority_types[source]
         if authority_type in penalize:
             authority_penalty = penalize[authority_type]
     return authority_penalty

--- a/ingestion_server/ingestion_server/categorize.py
+++ b/ingestion_server/ingestion_server/categorize.py
@@ -15,7 +15,7 @@ class Category(Enum):
 
 
 # Map each provider to a set of categories..
-provider_category = {
+source_category = {
     '__default': [],
     'thorvaldsenmuseum': [Category.DIGITIZED_ARTWORK],
     'svgsilh': [Category.ILLUSTRATION],
@@ -36,11 +36,11 @@ provider_category = {
 }
 
 
-def get_categories(extension, provider):
+def get_categories(extension, source):
     if extension and extension.lower() == 'svg':
         categories = [Category.ILLUSTRATION]
-    elif provider in provider_category:
-        categories = provider_category[provider]
+    elif source in source_category:
+        categories = source_category[source]
     else:
-        categories = provider_category['__default']
+        categories = source_category['__default']
     return [x.name for x in categories]

--- a/ingestion_server/ingestion_server/elasticsearch_models.py
+++ b/ingestion_server/ingestion_server/elasticsearch_models.py
@@ -72,6 +72,7 @@ class Image(SyncableDocType):
     @staticmethod
     def database_row_to_elasticsearch_doc(row, schema):
         provider = row[schema['provider']]
+        source = row[schema['source']]
         extension = Image.get_extension(row[schema['url']])
         height = row[schema['height']]
         width = row[schema['width']]
@@ -87,21 +88,21 @@ class Image(SyncableDocType):
             created_on=row[schema['created_on']],
             url=row[schema['url']],
             thumbnail=row[schema['thumbnail']],
-            provider=row[schema['provider']],
+            provider=provider,
             source=row[schema['source']],
             license=row[schema['license']].lower(),
             license_version=row[schema['license_version']],
             foreign_landing_url=row[schema['foreign_landing_url']],
             description=Image.parse_description(meta),
             extension=Image.get_extension(row[schema['url']]),
-            categories=get_categories(extension, provider),
+            categories=get_categories(extension, source),
             aspect_ratio=Image.get_aspect_ratio(height, width),
             size=Image.get_size(height, width),
             license_url=Image.get_license_url(meta),
             mature=Image.get_maturity(meta, row[schema['mature']]),
             normalized_popularity=Image.get_popularity(meta),
-            authority_boost=Image.get_authority_boost(meta, provider),
-            authority_penalty=Image.get_authority_penalty(meta, provider)
+            authority_boost=Image.get_authority_boost(meta, source),
+            authority_penalty=Image.get_authority_penalty(meta, source)
         )
 
     @staticmethod
@@ -187,7 +188,7 @@ class Image(SyncableDocType):
         return popularity
 
     @staticmethod
-    def get_authority_boost(meta_data, provider):
+    def get_authority_boost(meta_data, source):
         authority_boost = None
         if meta_data and 'authority_boost' in meta_data:
             try:
@@ -198,11 +199,11 @@ class Image(SyncableDocType):
             except (ValueError, TypeError):
                 pass
         else:
-            authority_boost = get_authority_boost(provider)
+            authority_boost = get_authority_boost(source)
         return authority_boost
 
     @staticmethod
-    def get_authority_penalty(meta_data, provider):
+    def get_authority_penalty(meta_data, source):
         authority_penalty = None
         if meta_data and 'authority_penalty' in meta_data:
             try:
@@ -213,7 +214,7 @@ class Image(SyncableDocType):
             except (ValueError, TypeError):
                 pass
         else:
-            authority_penalty = get_authority_penalty(provider)
+            authority_penalty = get_authority_penalty(source)
         return authority_penalty
 
     @staticmethod

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -23,4 +23,4 @@ curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model"
 # Ingest and index the data
 curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model": "image", "action": "INGEST_UPSTREAM"}'
 # Clear source cache since it's out of date after data has been loaded
-docker exec -it cccatalog-api_cache_1 /bin/bash -c "echo \"del :1:providers-image\" | redis-cli"
+docker exec -it cccatalog-api_cache_1 /bin/bash -c "echo \"del :1:source-image\" | redis-cli"

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -23,4 +23,4 @@ curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model"
 # Ingest and index the data
 curl -XPOST localhost:8001/task -H "Content-Type: application/json" -d '{"model": "image", "action": "INGEST_UPSTREAM"}'
 # Clear source cache since it's out of date after data has been loaded
-docker exec -it cccatalog-api_cache_1 /bin/bash -c "echo \"del :1:source-image\" | redis-cli"
+docker exec -it cccatalog-api_cache_1 /bin/bash -c "echo \"del :1:sources-image\" | redis-cli"


### PR DESCRIPTION
## Fixes https://github.com/creativecommons/cccatalog-api/issues/531
The display of different sources will be driven by the `source` field instead of `provider`. `provider` will now be used to display the originating platform.