### PR TITLE
Proxy thumbnails during serialization instead of through post-processing

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -10,9 +10,7 @@ from elasticsearch_dsl.response import Response, Hit
 from elasticsearch_dsl.query import Query
 from cccatalog import settings
 from django.core.cache import cache
-from django.urls import reverse
 from rest_framework import serializers
-from cccatalog.settings import PROXY_THUMBS
 from cccatalog.api.utils.validate_images import validate_images
 from cccatalog.api.utils.dead_link_mask import get_query_mask, get_query_hash
 from itertools import accumulate
@@ -119,13 +117,6 @@ def _post_process_results(s, start, end, page_size, search_results,
         if hasattr(res.meta, 'highlight'):
             res.fields_matched = dir(res.meta.highlight)
         to_validate.append(res.url)
-        if PROXY_THUMBS:
-            # Route all images through a dynamically resizing caching proxy.
-            proxied = "https://{}{}".format(
-                request.get_host(),
-                reverse('thumbs', kwargs={'identifier': res["identifier"]})
-            )
-            res[THUMBNAIL] = proxied
         results.append(res)
 
     if filter_dead:

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -345,9 +345,7 @@ class ImageSerializer(serializers.Serializer):
         request = self.context['request']
         host = request.get_host()
         path = reverse('thumbs', kwargs={'identifier': obj.identifier})
-        proxied = f'https://{host}{path}'
-        return proxied
-
+        return f'https://{host}{path}'
 
     def validate_url(self, value):
         return _add_protocol(value)

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -343,10 +343,9 @@ class ImageSerializer(serializers.Serializer):
 
     def get_thumbnail(self, obj):
         request = self.context['request']
-        proxied = "https://{}{}".format(
-            request.get_host(),
-            reverse('thumbs', kwargs={'identifier': obj.identifier})
-        )
+        host = request.get_host()
+        path = reverse('thumbs', kwargs={'identifier': obj.identifier})
+        proxied = f'https://{host}{path}'
         return proxied
 
 

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -1,6 +1,7 @@
 import cccatalog.api.licenses as license_helpers
 from rest_framework import serializers
 from cccatalog.api.licenses import LICENSE_GROUPS, get_license_url
+from django.urls import reverse
 from urllib.parse import urlparse
 from collections import namedtuple
 from cccatalog.api.controllers.search_controller import get_sources
@@ -273,6 +274,7 @@ def _add_protocol(url: str):
 
 class ImageSerializer(serializers.Serializer):
     """ A single image. Used in search results."""
+    requires_context = True
     title = serializers.CharField(required=False)
     id = serializers.CharField(
         required=True,
@@ -287,7 +289,7 @@ class ImageSerializer(serializers.Serializer):
         help_text="Tags with detailed metadata, such as accuracy."
     )
     url = serializers.URLField()
-    thumbnail = serializers.URLField(required=False, allow_blank=True)
+    thumbnail = serializers.SerializerMethodField()
     source = serializers.CharField(required=False, source='provider')
     license = serializers.SerializerMethodField()
     license_version = serializers.CharField(required=False)
@@ -338,6 +340,15 @@ class ImageSerializer(serializers.Serializer):
             return license_helpers.get_license_url(
                 obj.license, obj.license_version, None
             )
+
+    def get_thumbnail(self, obj):
+        request = self.context['request']
+        proxied = "https://{}{}".format(
+            request.get_host(),
+            reverse('thumbs', kwargs={'identifier': obj.identifier})
+        )
+        return proxied
+
 
     def validate_url(self, value):
         return _add_protocol(value)

--- a/cccatalog-api/cccatalog/settings.py
+++ b/cccatalog-api/cccatalog/settings.py
@@ -159,7 +159,6 @@ CACHES = {
 }
 
 # Produce CC-hosted thumbnails dynamically through a proxy.
-PROXY_THUMBS = bool(os.environ.get('PROXY_THUMBS', True))
 THUMBNAIL_PROXY_URL = os.environ.get(
     'THUMBNAIL_PROXY_URL', 'http://localhost:8222'
 )


### PR DESCRIPTION
## Fixes https://github.com/creativecommons/cccatalog-api/issues/541

## Details
Thumbnails should always be routed through our image proxy. To do this consistently, move proxying logic from view post-processing to serialization layer.

FYI @makkoncept