### PR TITLE
Skip validation of thumbnail URLs

### DIFF
--- a/ingestion_server/ingestion_server/cleanup.py
+++ b/ingestion_server/ingestion_server/cleanup.py
@@ -132,8 +132,7 @@ _cleanup_config = {
                         'tags': CleanupFunctions.cleanup_tags,
                         'url': CleanupFunctions.cleanup_url,
                         'creator_url': CleanupFunctions.cleanup_url,
-                        'foreign_landing_url': CleanupFunctions.cleanup_url,
-                        'thumbnail': CleanupFunctions.cleanup_url
+                        'foreign_landing_url': CleanupFunctions.cleanup_url
                     }
                 }
             }


### PR DESCRIPTION
We no longer display third party thumbnail URLs, so we shouldn't waste time cleaning them up.