### PR TITLE
Preserve aspect ratio in thumbnails

### DIFF
--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -346,7 +346,7 @@ class ImageSerializer(serializers.Serializer):
         request = self.context['request']
         host = request.get_host()
         path = reverse('thumbs', kwargs={'identifier': obj.identifier})
-        return f'https://{host}{path}'
+        return f'https://{host}/600,fit{path}'
 
     def validate_url(self, value):
         return _add_protocol(value)


### PR DESCRIPTION
## Fixes https://github.com/creativecommons/cccatalog-api/issues/564

## Description
Our thumbnail proxy isn't correctly configured to preserve aspect ratios, resulting in all images in the search results being squares. This change fixes that issue and also sets the thumbnail resolution instead of taking imageproxy's default.

More information about imageproxy parameters can be found [here](https://github.com/willnorris/imageproxy).