### PR TITLE
Exclude filtered sources from recommendations endpoint

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -171,6 +171,7 @@ def _apply_filter(s: Search, search_params, param_name, renamed_param=None):
     else:
         return s
 
+
 def _exclude_filtered(s: Search):
     """
     Hide data sources from the catalog dynamically.
@@ -190,10 +191,12 @@ def _exclude_filtered(s: Search):
     s = s.exclude('terms', provider=to_exclude)
     return s
 
+
 def _exclude_mature_by_param(s: Search, search_params):
     if not search_params.data['mature']:
         s = s.exclude('term', mature=True)
     return s
+
 
 def search(search_params, index, page_size, ip, request,
            filter_dead, page=1) -> Tuple[List[Hit], int, int]:

--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -18,7 +18,8 @@ from typing import Tuple, List, Optional
 from math import ceil
 
 ELASTICSEARCH_MAX_RESULT_WINDOW = 10000
-CACHE_TIMEOUT = 60 * 20
+SOURCE_CACHE_TIMEOUT = 60 * 20
+FILTER_CACHE_TIMEOUT = 30
 DEAD_LINK_RATIO = 1 / 2
 THUMBNAIL = 'thumbnail'
 URL = 'url'
@@ -184,7 +185,7 @@ def _exclude_filtered(s: Search):
             .values('provider_identifier')
         cache.set(
             key=filter_cache_key,
-            timeout=CACHE_TIMEOUT,
+            timeout=FILTER_CACHE_TIMEOUT,
             value=filtered_providers
         )
     to_exclude = [f['provider_identifier'] for f in filtered_providers]
@@ -440,7 +441,7 @@ def get_sources(index):
         sources = {result['key']: result['doc_count'] for result in buckets}
         cache.set(
             key=source_cache_name,
-            timeout=CACHE_TIMEOUT,
+            timeout=SOURCE_CACHE_TIMEOUT,
             value=sources
         )
     return sources


### PR DESCRIPTION
## Fixes https://github.com/creativecommons/cccatalog-api/issues/592

## Description
Disabled sources can appear in image recommendations. We need to factor out the filtering logic to be reusable in other search endpoints.

This also reduces the amount of time that we cache filters to alleviate pain caused by https://github.com/creativecommons/cccatalog-api/issues/583. We'll cache filtered sources for 30 seconds instead of 20 minutes.