### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 * @creativecommons/backend @creativecommons/ct-cc-catalog-api-collaborators
+* @creativecommons/ct-cc-catalog-api-core-committers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.