### PR TITLE
Name exact invalid source when source validation fails

### DIFF
--- a/cccatalog-api/cccatalog/api/controllers/search_controller.py
+++ b/cccatalog-api/cccatalog/api/controllers/search_controller.py
@@ -338,16 +338,6 @@ def search(search_params, index, page_size, ip, request,
     return results, page_count, result_count
 
 
-def _validate_provider(input_provider):
-    allowed_providers = list(get_sources('image').keys())
-    lowercase_providers = [x.lower() for x in allowed_providers]
-    if input_provider.lower() not in lowercase_providers:
-        raise serializers.ValidationError(
-            "Provider \'{}\' does not exist.".format(input_provider)
-        )
-    return input_provider.lower()
-
-
 def related_images(uuid, index, request, filter_dead):
     """
     Given a UUID, find related search results.

--- a/cccatalog-api/cccatalog/api/serializers/image_serializers.py
+++ b/cccatalog-api/cccatalog/api/serializers/image_serializers.py
@@ -206,15 +206,15 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
             return 20
 
     @staticmethod
-    def validate_source(input_providers):
-        allowed_providers = list(get_sources('image').keys())
+    def validate_source(input_sources):
+        allowed_sources = list(get_sources('image').keys())
 
-        for input_provider in input_providers.split(','):
-            if input_provider not in allowed_providers:
+        for input_source in input_sources.split(','):
+            if input_source not in allowed_sources:
                 raise serializers.ValidationError(
-                    "Provider \'{}\' does not exist.".format(input_providers)
+                    f"Source \'{input_source}\' does not exist."
                 )
-        return input_providers.lower()
+        return input_sources.lower()
 
     @staticmethod
     def validate_extension(value):


### PR DESCRIPTION
## Related to https://github.com/creativecommons/cccatalog-api/issues/613

## Description
When a user tries to search for a non-existent source, we raise an error. This PR makes the error more informative; we'll list the exact problematic source instead of returning the entire list of sources.

For example:
`GET /v1/images?source=behance,flickr,blah`

Before this PR:
```
{
   "detail" : "Invalid input given for fields. 'source' -> Provider 'flickr,behance,blah' does not exist.",
   "error" : "InputError",
   "fields" : [
      "source"
   ]
}
```

After this PR:
```
{
   "fields" : [
      "source"
   ],
   "error" : "InputError",
   "detail" : "Invalid input given for fields. 'source' -> Source 'blah' does not exist."
}
```