### PR TITLE
Replace ORG_GITHUB_TOKEN with ADMIN_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/IssueAndPR.yml
+++ b/.github/workflows/IssueAndPR.yml
@@ -13,7 +13,7 @@ jobs:
       uses: docker://takanabe/github-actions-automate-projects:v0.0.1
       if: github.event_name == 'issues'
       env:
-        GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         GITHUB_PROJECT_URL: https://github.com/orgs/creativecommons/projects/10
         GITHUB_PROJECT_COLUMN_NAME: "Pending Review"
     - name: "Automate adding PRs to Active Sprint"
@@ -21,6 +21,6 @@ jobs:
       if: github.event_name == 'pull_request'
       continue-on-error: true
       env:
-        GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         GITHUB_PROJECT_URL: https://github.com/orgs/creativecommons/projects/7
         GITHUB_PROJECT_COLUMN_NAME: "In Progress"


### PR DESCRIPTION
## Description
For consistency, all code must use `ADMIN_GITHUB_TOKEN` instead of `ORG_GITHUB_TOKEN`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
