### PR TITLE
Move analytics migrations to openledger database

### DIFF
--- a/analytics/settings.py
+++ b/analytics/settings.py
@@ -1,7 +1,7 @@
 import os
 
 DATABASE_CONNECTION = os.getenv(
-    'DATABASE_CONN', 'postgres+psycopg2://deploy:deploy@localhost/analytics'
+    'DATABASE_CONN', 'postgres+psycopg2://deploy:deploy@localhost/openledger'
 )
 
 # Attribution events stream configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,4 +151,4 @@ services:
     ports:
       - "8090:8090"
     environment:
-      DATABASE_CONN: 'postgres+psycopg2://deploy:deploy@db/analytics'
+      DATABASE_CONN: 'postgres+psycopg2://deploy:deploy@db/openledger'

--- a/load_sample_data.sh
+++ b/load_sample_data.sh
@@ -11,8 +11,7 @@ user = User.objects.create_user('continuous_integration', 'test@test.test', 'dep
 user.save()
 "
 EOF
-# Create analytics database
-PGPASSWORD=deploy createdb -h localhost -U deploy analytics
+# Migrate analytics
 docker exec -i $ANALYTICS_CONTAINER_NAME /bin/bash -c 'PYTHONPATH=. pipenv run alembic upgrade head'
 PGPASSWORD=deploy pg_dump -s -t image -U deploy -d openledger -h localhost -p 5432 | PGPASSWORD=deploy psql -U deploy -d openledger -p 5433 -h localhost
 # Load sample data


### PR DESCRIPTION
## Related to https://github.com/creativecommons/ccsearch-infrastructure/issues/99

## Description
The analytics data needs to be kept in the same database as the image data so we can do efficient joins. Doing this over the foreign data wrapper interface is too slow.
